### PR TITLE
✨ テーマ切り替えアニメーション機能を追加

### DIFF
--- a/.kiro/specs/theme-toggle-animation/design.md
+++ b/.kiro/specs/theme-toggle-animation/design.md
@@ -1,0 +1,269 @@
+# Design Document
+
+## Overview
+
+テーマ切り替え時に月と太陽が入れ替わるアニメーションを追加する。v0で作成したコンポーネントをベースに、Astro環境向けに新規コンポーネント`ThemeToggleAnimated.tsx`を作成する。
+
+### アプローチ
+**パターンC: ハイブリッド**
+- 新規ファイル `ThemeToggleAnimated.tsx` を作成
+- 統合完了後、不要なコンポーネント（`ThemeToggle.tsx`, `theme-toggle.tsx`）を削除
+
+### 主要な演出
+1. **波エフェクト**: ボタンを中心に円形の波が画面全体に広がる
+2. **アイコンアニメーション（大）**: 画面中央で太陽/月アイコンがスライドイン/アウト
+3. **アイコンアニメーション（小）**: ボタン内のアイコンが縦方向にスライド
+
+## Architecture
+
+### Component Hierarchy
+
+```
+Header.astro
+└── ThemeToggleAnimated (client:load)
+    ├── Toggle Button (in header, z-50)
+    │   └── Small Icons (translate-y animation)
+    └── Portal → document.body
+        ├── Wave Overlay (z-40)
+        │   └── Expanding Circle
+        └── Icon Overlay (z-50)
+            ├── Sun Icon (large)
+            └── Moon Icon (large)
+```
+
+### State Management
+
+```typescript
+// コンポーネント内部状態
+interface ThemeToggleState {
+  isDark: boolean;                    // 現在のテーマ
+  mounted: boolean;                   // クライアントマウント完了
+  isAnimating: boolean;               // アニメーション実行中
+  showWave: boolean;                  // 波オーバーレイ表示
+  waveStyle: React.CSSProperties;     // 波の動的スタイル
+  iconPhase: "idle" | "exit" | "enter"; // アイコンアニメーション段階
+}
+
+// refs
+buttonRef: RefObject<HTMLButtonElement>  // ボタン位置取得用
+```
+
+### Animation Timeline
+
+```
+0ms     - toggleTheme() 呼び出し
+        - isAnimating = true
+        - iconPhase = "exit"
+        - showWave = true
+        - 波のスタイル計算（ボタン位置を中心に）
+        - 現在のアイコン（大）がスライドアウト
+        - 波が scale(0) → scale(1) へ展開開始
+
+300ms   - テーマ切り替え実行（DOM class変更、localStorage保存）
+        - iconPhase = "enter"
+        - 新しいアイコン（大）がスライドイン
+
+600ms   - showWave = false
+        - 波がフェードアウト
+
+900ms   - isAnimating = false
+        - iconPhase = "idle"
+        - アニメーション完了
+```
+
+## Component Details
+
+### ThemeToggleAnimated.tsx
+
+#### Props
+```typescript
+// Propsなし - 自己完結型コンポーネント
+export function ThemeToggleAnimated(): JSX.Element
+```
+
+#### Internal Functions
+
+```typescript
+// DOM状態から現在のテーマを取得（ThemeInit.astroで設定済み）
+function getInitialTheme(): boolean // isDark
+
+// テーマ切り替えハンドラー
+function toggleTheme(): void
+```
+
+#### Key Implementation Points
+
+1. **React Portal による2層オーバーレイ**
+   ```typescript
+   import { createPortal } from "react-dom";
+
+   // 波オーバーレイ（z-40）
+   {mounted && createPortal(
+     <div className="fixed inset-0 z-40 pointer-events-none">
+       <div
+         className="absolute rounded-full"
+         style={waveStyle}
+       />
+     </div>,
+     document.body
+   )}
+
+   // アイコンオーバーレイ（z-50）
+   {mounted && createPortal(
+     <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+       {/* 大きなアイコン */}
+     </div>,
+     document.body
+   )}
+   ```
+
+2. **波エフェクトの計算**
+   ```typescript
+   const toggleTheme = useCallback(() => {
+     const button = buttonRef.current;
+     const rect = button.getBoundingClientRect();
+     const x = rect.left + rect.width / 2;
+     const y = rect.top + rect.height / 2;
+
+     // 画面の対角線の長さを計算
+     const maxDistance = Math.sqrt(
+       Math.max(x, window.innerWidth - x) ** 2 +
+       Math.max(y, window.innerHeight - y) ** 2
+     );
+
+     setWaveStyle({
+       left: x,
+       top: y,
+       width: maxDistance * 2,
+       height: maxDistance * 2,
+       transform: "translate(-50%, -50%) scale(0)",
+     });
+
+     // requestAnimationFrameで波を展開
+     requestAnimationFrame(() => {
+       setWaveStyle(prev => ({
+         ...prev,
+         transform: "translate(-50%, -50%) scale(1)",
+         transition: "transform 600ms cubic-bezier(0.4, 0, 0.2, 1)",
+       }));
+     });
+   }, []);
+   ```
+
+3. **SSRハイドレーション対策**
+   ```typescript
+   const [mounted, setMounted] = useState(false);
+   useEffect(() => setMounted(true), []);
+
+   // マウント前はプレースホルダーを返す
+   if (!mounted) {
+     return <button className="..."><div className="w-5 h-5" /></button>;
+   }
+   ```
+
+4. **ボタン内アイコンのアニメーション（縦方向）**
+   ```typescript
+   // 太陽アイコン（小）
+   className={`... ${
+     isDark ? "translate-y-full opacity-0" : "translate-y-0 opacity-100"
+   }`}
+
+   // 月アイコン（小）
+   className={`... ${
+     isDark ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0"
+   }`}
+   ```
+
+5. **大きなアイコンのアニメーション（横方向）**
+   ```typescript
+   // 太陽アイコン（大）- ライトモードへ切り替え時
+   className={`... ${
+     !isDark && iconPhase === "enter"
+       ? "translate-x-0 opacity-100"
+       : !isDark && iconPhase === "exit"
+       ? "translate-x-full opacity-0"
+       : "-translate-x-full opacity-0"
+   }`}
+
+   // 月アイコン（大）- ダークモードへ切り替え時
+   className={`... ${
+     isDark && iconPhase === "enter"
+       ? "translate-x-0 opacity-100"
+       : isDark && iconPhase === "exit"
+       ? "translate-x-full opacity-0"
+       : "translate-x-full opacity-0"
+   }`}
+   ```
+
+## Styling
+
+### Color Scheme
+- **テーマカラー**: `text-foreground` CSS変数を使用
+- **波の背景色**:
+  - ダークモードへ: `rgb(10, 10, 10)`
+  - ライトモードへ: `rgb(250, 250, 250)`
+- **オーバーレイ背景**: 透明（`pointer-events-none`）
+
+### Z-Index Hierarchy
+```
+z-40  - 波オーバーレイ
+z-50  - アイコンオーバーレイ、トグルボタン
+```
+
+### CSS Transitions
+
+```css
+/* 波の展開 */
+transition: transform 600ms cubic-bezier(0.4, 0, 0.2, 1);
+
+/* アイコンのスライド */
+transition: all 300ms ease-out;
+
+/* オーバーレイのフェード */
+transition: opacity 200ms-300ms;
+```
+
+## File Changes
+
+### New Files
+| ファイル | 説明 |
+|---------|------|
+| `src/components/ThemeToggleAnimated.tsx` | アニメーション付きテーマトグル |
+
+### Modified Files
+| ファイル | 変更内容 |
+|---------|----------|
+| `src/components/Header.astro` | import先を `ThemeToggleAnimated` に変更 |
+
+### Files to Delete (after integration & E2E test pass)
+| ファイル | 理由 |
+|---------|------|
+| `src/components/ThemeToggle.tsx` | `ThemeToggleAnimated` に置き換え |
+| `src/components/theme-toggle.tsx` | ソースとして使用完了 |
+
+## Accessibility
+
+- **aria-label**: 「テーマを切り替える」を設定
+- **aria-hidden**: アイコンSVGには不要（ボタンにaria-labelがあるため）
+- **disabled状態**: アニメーション中は `disabled` 属性と `disabled:cursor-not-allowed` スタイル
+- **pointer-events**: オーバーレイは `pointer-events-none` でユーザー操作を妨げない
+
+## Testing Considerations
+
+### Unit Tests
+- テーマ切り替え機能のテスト
+- localStorage保存のテスト
+
+### E2E Tests
+- テーマ切り替えボタンのクリック動作
+- テーマの永続化（ページリロード後）
+- 波エフェクトがボタン位置から展開されることの確認
+
+### Visual Regression
+- アニメーションのスムーズさ確認
+- 波がヘッダーより前面に表示されることの確認
+
+## Dependencies
+
+- **既存**: React, react-dom, Tailwind CSS
+- **追加なし**: 外部ライブラリの追加は不要

--- a/.kiro/specs/theme-toggle-animation/requirements.md
+++ b/.kiro/specs/theme-toggle-animation/requirements.md
@@ -1,0 +1,73 @@
+# Requirements Document
+
+## Introduction
+本仕様は、ブログのダークモード/ライトモード切り替え時に、月と太陽が入れ替わる演出アニメーションを追加する機能を定義する。v0で作成したNext.js用コンポーネントをベースに、Astro環境向けに移植・実装する。
+
+## Requirements
+
+### Requirement 1: テーマ切り替えトリガー
+**Objective:** ユーザーとして、テーマ切り替えボタンをクリックしてダーク/ライトモードを切り替えたい。これにより、好みの表示モードでブログを閲覧できる。
+
+#### Acceptance Criteria
+1. When ユーザーがテーマ切り替えボタンをクリックする, the ThemeToggleコンポーネント shall 現在のテーマを反転させる（light→dark または dark→light）
+2. While アニメーションが実行中, the ThemeToggleコンポーネント shall ボタンのクリックを無効化する
+3. The ThemeToggleコンポーネント shall 選択されたテーマをlocalStorageに保存する
+
+### Requirement 2: アイコン切り替えアニメーション（大）
+**Objective:** ユーザーとして、テーマ切り替え時に画面中央で大きな月と太陽のアイコンが入れ替わるアニメーションを見たい。これにより、テーマ変更を視覚的に楽しめる。
+
+#### Acceptance Criteria
+1. When テーマがライトモードからダークモードに切り替わる, the ThemeToggleコンポーネント shall 画面中央で太陽アイコン（大）をカットアウト（右方向へスライドアウト）し、月アイコン（大）をカットイン（左方向からスライドイン）する
+2. When テーマがダークモードからライトモードに切り替わる, the ThemeToggleコンポーネント shall 画面中央で月アイコン（大）をカットアウト（右方向へスライドアウト）し、太陽アイコン（大）をカットイン（左方向からスライドイン）する
+3. The アニメーション shall 約1秒以内に完了する
+
+### Requirement 3: アイコン切り替えアニメーション（小・ボタン内）
+**Objective:** ユーザーとして、ボタン内のアイコンもテーマに合わせてアニメーションで切り替わるのを見たい。
+
+#### Acceptance Criteria
+1. When テーマがライトモードの場合, the ボタン内 shall 太陽アイコン（小）を表示する
+2. When テーマがダークモードの場合, the ボタン内 shall 月アイコン（小）を表示する
+3. When テーマが切り替わる, the ボタン内アイコン shall 縦方向にスライド（translate-y）してアニメーションする
+
+### Requirement 4: 波エフェクト演出
+**Objective:** ユーザーとして、テーマ切り替え時にボタンを中心に波のように広がるエフェクトを見たい。これにより、より印象的な切り替え体験ができる。
+
+#### Acceptance Criteria
+1. When テーマ切り替えが開始される, the ThemeToggleコンポーネント shall ボタン位置を中心に円形の波を画面全体に展開する
+2. The 波 shall ダークモードへの切り替え時は暗い色（rgb(10,10,10)）、ライトモードへの切り替え時は明るい色（rgb(250,250,250)）で表示する
+3. The 波 shall 約600msかけてscale(0)からscale(1)へ展開する
+4. When アニメーションが完了する, the 波 shall フェードアウトして非表示になる
+5. The 波オーバーレイ shall pointer-events: noneでユーザー操作を妨げない
+
+### Requirement 5: フルスクリーンオーバーレイ演出
+**Objective:** ユーザーとして、テーマ切り替え時に画面中央で大きなアイコンのアニメーションを見たい。これにより、より印象的な切り替え体験ができる。
+
+#### Acceptance Criteria
+1. When テーマ切り替えアニメーションが開始される, the ThemeToggleコンポーネント shall 画面全体にアイコン用オーバーレイを表示する
+2. While オーバーレイが表示されている, the ThemeToggleコンポーネント shall 画面中央に大きな太陽/月アイコンのアニメーションを表示する
+3. When アニメーションが完了する, the オーバーレイ shall フェードアウトして非表示になる
+4. The オーバーレイ shall pointer-events: noneでユーザー操作を妨げない
+
+### Requirement 6: 初期テーマ設定
+**Objective:** ユーザーとして、ページ読み込み時に以前選択したテーマまたはOSの設定に基づいてテーマが適用されてほしい。これにより、一貫した表示体験ができる。
+
+#### Acceptance Criteria
+1. When ページが読み込まれる, the ThemeToggleコンポーネント shall localStorageに保存されたテーマを優先的に適用する
+2. If localStorageにテーマが保存されていない, then the ThemeToggleコンポーネント shall OSのprefers-color-scheme設定に従ってテーマを適用する
+3. The ThemeToggleコンポーネント shall SSRハイドレーションミスマッチを防ぐため、マウント後にテーマ状態を同期する
+
+### Requirement 7: Astro環境への適合
+**Objective:** 開発者として、Next.js用のコンポーネントをAstro環境で動作させたい。これにより、既存のブログ基盤との統合ができる。
+
+#### Acceptance Criteria
+1. The ThemeToggleコンポーネント shall Reactコンポーネントとして実装され、Astroの`client:load`ディレクティブで読み込まれる
+2. The ThemeToggleコンポーネント shall 既存のThemeInit.astroと互換性を持ち、テーマ初期化ロジックと連携する
+3. The オーバーレイ shall React Portalを使用してbody直下にレンダリングされ、Headerのスタッキングコンテキストの影響を受けない
+4. The ThemeToggleコンポーネント shall 既存のTailwind CSSテーマカラー（--foreground等）を使用する
+
+### Requirement 8: アクセシビリティ
+**Objective:** ユーザーとして、スクリーンリーダーや支援技術を使用してもテーマ切り替え機能を利用したい。
+
+#### Acceptance Criteria
+1. The テーマ切り替えボタン shall 適切なaria-label属性を持つ（例：「テーマを切り替える」）
+2. While アニメーション中, the ボタン shall disabled状態を示し、disabled:cursor-not-allowedスタイルを適用する

--- a/.kiro/specs/theme-toggle-animation/research.md
+++ b/.kiro/specs/theme-toggle-animation/research.md
@@ -1,0 +1,91 @@
+# Research Notes
+
+## Discovery Phase Findings
+
+### 既存コンポーネント分析
+
+#### 1. ThemeToggle.tsx（本番環境で使用中）
+- **場所**: `src/components/ThemeToggle.tsx`
+- **機能**: シンプルなテーマ切り替え（アニメーションなし）
+- **特徴**:
+  - shadcn/ui `Button` コンポーネントを使用
+  - `getInitialTheme()` でDOM状態から初期テーマを取得
+  - SSRハイドレーションミスマッチ防止パターン実装済み
+  - aria-labelでアクセシビリティ対応
+
+#### 2. theme-toggle.tsx（v0作成、未統合）
+- **場所**: `src/components/theme-toggle.tsx`
+- **機能**: アニメーション付きテーマ切り替え
+- **特徴**:
+  - `animationPhase`: "idle" | "cut-out" | "cut-in" の3状態
+  - アニメーションタイミング: 350ms (切り替え) → 700ms (フェードアウト) → 1000ms (完了)
+  - フルスクリーンオーバーレイ表示
+  - `text-foreground/80` でモノトーンスタイリング
+  - **問題点**: `"use client"` ディレクティブはNext.js用（Astroでは不要）
+
+#### 3. ThemeInit.astro
+- **場所**: `src/components/ThemeInit.astro`
+- **機能**: FOUC防止のためのインラインスクリプト
+- **特徴**:
+  - `is:inline` でバンドルされないスクリプト
+  - localStorage → prefers-color-scheme の優先順位でテーマ決定
+  - エラーハンドリング（プライベートブラウジング対応）
+
+#### 4. Header.astro
+- **場所**: `src/components/Header.astro`
+- **機能**: サイトヘッダー
+- **特徴**:
+  - `z-50` のスタッキングコンテキスト
+  - `ThemeToggle` を `client:load` で読み込み
+  - **問題**: オーバーレイがヘッダー内に閉じ込められる
+
+### 技術的調査
+
+#### React Portal の必要性
+- Header.astro は `z-50` のスタッキングコンテキストを持つ
+- フルスクリーンオーバーレイを表示するには、Headerの外にレンダリングが必要
+- `createPortal(element, document.body)` を使用して解決
+
+#### createPortal 使用パターン
+```typescript
+import { createPortal } from "react-dom";
+
+// マウント後にのみPortalを使用
+const [mounted, setMounted] = useState(false);
+useEffect(() => setMounted(true), []);
+
+// オーバーレイのレンダリング
+{mounted && showOverlay && createPortal(
+  <div className="fixed inset-0 z-[100]">...</div>,
+  document.body
+)}
+```
+
+#### Astro環境での考慮事項
+- `"use client"` ディレクティブは不要（削除する）
+- `client:load` でハイドレーション
+- ThemeInit.astro との互換性を維持
+
+### デザイン決定
+
+#### アプローチ: パターンC（ハイブリッド）
+- **新規作成**: `ThemeToggleAnimated.tsx`
+- **ベース**: `theme-toggle.tsx` のアニメーションロジック
+- **追加機能**:
+  - React Portal でオーバーレイを body 直下にレンダリング
+  - `ThemeToggle.tsx` のSSRハイドレーションパターンを採用
+- **後処理**: 統合完了後、不要なコンポーネントを削除
+
+#### カラースキーム
+- `--foreground` / `--background` テーマ変数を使用
+- オーバーレイ背景: `rgba(0,0,0,0.03)` / `rgba(255,255,255,0.03)`
+- アイコン: `text-foreground/80`
+
+### 関連ファイル一覧
+| ファイル | 役割 | 変更予定 |
+|---------|------|---------|
+| `src/components/ThemeToggleAnimated.tsx` | 新規コンポーネント | 新規作成 |
+| `src/components/Header.astro` | ヘッダー | import先変更 |
+| `src/components/ThemeToggle.tsx` | 現行コンポーネント | 統合後削除 |
+| `src/components/theme-toggle.tsx` | v0ソース | 統合後削除 |
+| `src/components/ThemeInit.astro` | FOUC防止 | 変更なし |

--- a/.kiro/specs/theme-toggle-animation/spec.json
+++ b/.kiro/specs/theme-toggle-animation/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "theme-toggle-animation",
+  "created_at": "2026-01-19T20:45:00+09:00",
+  "updated_at": "2026-01-19T22:00:00+09:00",
+  "language": "ja",
+  "phase": "implementation",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/theme-toggle-animation/tasks.md
+++ b/.kiro/specs/theme-toggle-animation/tasks.md
@@ -1,0 +1,88 @@
+# Implementation Plan
+
+## Tasks
+
+- [x] 1. ThemeToggleAnimatedコンポーネントの基本構造を実装する
+- [x] 1.1 コンポーネントの状態管理とマウント処理を実装する
+  - isDark, mounted, isAnimating, showWave, waveStyle, iconPhase の状態を定義
+  - buttonRefを使用してボタン要素への参照を保持
+  - useEffectでマウント完了を検知し、ThemeInit.astroで設定済みのテーマをDOMから読み取る
+  - マウント前はプレースホルダーボタンを返してSSRハイドレーションミスマッチを防止
+  - _Requirements: 6.1, 6.2, 6.3_
+
+- [x] 1.2 テーマ切り替えのコアロジックを実装する
+  - toggleTheme関数でテーマの反転処理を実装（light↔dark）
+  - document.documentElement.classListでdarkクラスを切り替え
+  - localStorageにテーマを保存
+  - isAnimating中はボタンクリックを無効化
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [x] 2. トグルボタンとボタン内アイコンアニメーションを実装する
+  - ボタン要素にref、onClick、disabled、aria-labelを設定
+  - 太陽アイコン（小）と月アイコン（小）をボタン内に配置
+  - テーマ状態に応じてtranslate-yでアイコンを縦方向にスライド
+  - アニメーション中はdisabled:cursor-not-allowedスタイルを適用
+  - _Requirements: 3.1, 3.2, 3.3, 8.1, 8.2_
+
+- [x] 3. 波エフェクト演出を実装する
+- [x] 3.1 波のサイズと位置の計算ロジックを実装する
+  - buttonRefから現在のボタン位置を取得
+  - ボタン中心から画面の対角線までの最大距離を計算
+  - waveStyleに初期状態（scale(0)、ボタン中心位置）を設定
+  - _Requirements: 4.1_
+
+- [x] 3.2 波の展開アニメーションとオーバーレイを実装する
+  - React Portalで波オーバーレイをbody直下にレンダリング（z-40）
+  - requestAnimationFrameでscale(0)→scale(1)へのトランジションを開始
+  - 600msのcubic-bezierイージングで滑らかに展開
+  - テーマに応じた背景色を設定（rgb(10,10,10) / rgb(250,250,250)）
+  - pointer-events: noneでユーザー操作を妨げない
+  - _Requirements: 4.2, 4.3, 4.4, 4.5_
+
+- [x] 4. フルスクリーンアイコンオーバーレイを実装する
+- [x] 4.1 大きなアイコンのカットイン/カットアウトアニメーションを実装する
+  - React Portalでアイコンオーバーレイをbody直下にレンダリング（z-50）
+  - 太陽アイコン（大）と月アイコン（大）を画面中央に配置
+  - iconPhaseに応じてtranslate-xでアイコンを横方向にスライド
+  - exit時：現在のアイコンが右方向へスライドアウト
+  - enter時：新しいアイコンが左方向からスライドイン
+  - _Requirements: 2.1, 2.2, 5.1, 5.2_
+
+- [x] 4.2 (P) オーバーレイのフェードアウト処理を実装する
+  - アニメーション完了後にオーバーレイをフェードアウト
+  - pointer-events: noneでユーザー操作を妨げない
+  - _Requirements: 5.3, 5.4_
+
+- [x] 5. アニメーションタイムラインを統合する
+  - 0ms: isAnimating=true, iconPhase="exit", showWave=true, 波展開開始
+  - 300ms: テーマ切り替え実行、iconPhase="enter"
+  - 600ms: showWave=false
+  - 900ms: isAnimating=false, iconPhase="idle"
+  - setTimeoutを使用してタイミングを制御
+  - 全アニメーションが約1秒以内に完了することを確認
+  - _Requirements: 2.3_
+
+- [x] 6. Header.astroとの統合
+  - Header.astroのimport文をThemeToggleAnimatedに変更
+  - client:loadディレクティブでReactコンポーネントをハイドレーション
+  - 既存のThemeInit.astroとの互換性を確認
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+- [ ] 7. E2Eテストで動作を検証する
+  - テーマ切り替えボタンのクリックでテーマが反転することを確認
+  - ページリロード後もテーマが永続化されていることを確認
+  - オーバーレイがヘッダーより前面に表示されることを確認
+  - _Requirements: 1.1, 1.3, 7.3_
+
+## Requirements Coverage
+
+| 要件ID | タスク |
+|--------|--------|
+| 1.1, 1.2, 1.3 | 1.2, 7 |
+| 2.1, 2.2, 2.3 | 4.1, 5 |
+| 3.1, 3.2, 3.3 | 2 |
+| 4.1, 4.2, 4.3, 4.4, 4.5 | 3.1, 3.2 |
+| 5.1, 5.2, 5.3, 5.4 | 4.1, 4.2 |
+| 6.1, 6.2, 6.3 | 1.1 |
+| 7.1, 7.2, 7.3, 7.4 | 6, 7 |
+| 8.1, 8.2 | 2 |

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,6 @@
 ---
 import { MobileMenu } from "@/components/MobileMenu";
-import { ThemeToggle } from "@/components/ThemeToggle";
+import { ThemeToggleAnimated } from "@/components/ThemeToggleAnimated";
 
 const navItems = [
   { href: "/", label: "Home" },
@@ -54,7 +54,7 @@ const navItems = [
       </nav>
       {/* モバイルメニュー */}
       <MobileMenu navItems={navItems} client:load />
-      <ThemeToggle client:load />
+      <ThemeToggleAnimated client:load />
     </div>
   </div>
 </header>

--- a/src/components/ThemeToggleAnimated.tsx
+++ b/src/components/ThemeToggleAnimated.tsx
@@ -1,0 +1,190 @@
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { MoonIcon, SunIcon } from "./icons";
+
+// DOM状態から現在のテーマを取得（ThemeInit.astroで設定済み）
+function getInitialTheme(): boolean {
+  if (typeof document !== "undefined") {
+    return document.documentElement.classList.contains("dark");
+  }
+  return false;
+}
+
+export function ThemeToggleAnimated() {
+  const [isDark, setIsDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [showWave, setShowWave] = useState(false);
+  const [waveStyle, setWaveStyle] = useState<React.CSSProperties>({});
+  const [iconPhase, setIconPhase] = useState<"idle" | "exit" | "enter">("idle");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // マウント時にテーマ状態を同期
+  useEffect(() => {
+    setMounted(true);
+    setIsDark(getInitialTheme());
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    if (isAnimating) return;
+
+    // 波の起点を決定
+    // ダーク→ライト: 左下から右上へ
+    // ライト→ダーク: 右上から左下へ
+    const waveX = isDark ? 0 : window.innerWidth;
+    const waveY = isDark ? window.innerHeight : 0;
+
+    // 画面の対角線の長さを計算（波が画面全体を覆うために必要な半径）
+    const maxDistance = Math.sqrt(window.innerWidth ** 2 + window.innerHeight ** 2);
+
+    setIsAnimating(true);
+    setIconPhase("exit");
+
+    // 波のスタイルを設定
+    setWaveStyle({
+      left: waveX,
+      top: waveY,
+      width: maxDistance * 2,
+      height: maxDistance * 2,
+      transform: "translate(-50%, -50%) scale(0)",
+    });
+    setShowWave(true);
+
+    // 波を広げる
+    requestAnimationFrame(() => {
+      setWaveStyle((prev) => ({
+        ...prev,
+        transform: "translate(-50%, -50%) scale(1)",
+        transition: "transform 600ms cubic-bezier(0.16, 1, 0.3, 1)",
+      }));
+    });
+
+    // テーマを切り替え（波が半分くらい広がったタイミング）
+    setTimeout(() => {
+      const newDark = !isDark;
+      setIsDark(newDark);
+      if (newDark) {
+        document.documentElement.classList.add("dark");
+        localStorage.setItem("theme", "dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+        localStorage.setItem("theme", "light");
+      }
+      setIconPhase("enter");
+    }, 300);
+
+    // 波をフェードアウト
+    setTimeout(() => {
+      setShowWave(false);
+    }, 600);
+
+    // アニメーション完了
+    setTimeout(() => {
+      setIsAnimating(false);
+      setIconPhase("idle");
+      setWaveStyle({});
+    }, 900);
+  }, [isDark, isAnimating]);
+
+  // SSRハイドレーション対策：マウント前はプレースホルダーを返す
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        className="relative w-10 h-10 rounded-full flex items-center justify-center"
+      >
+        <div className="w-5 h-5" />
+      </button>
+    );
+  }
+
+  return (
+    <>
+      {/* 波オーバーレイ - React Portal でbody直下にレンダリング */}
+      {createPortal(
+        <div
+          className={`fixed inset-0 z-60 pointer-events-none overflow-hidden transition-opacity duration-200 ${
+            showWave ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          {/* 波（円形に広がる） */}
+          <div
+            className="absolute rounded-full opacity-80"
+            style={{
+              ...waveStyle,
+              backgroundColor: isDark ? "rgb(250, 250, 250)" : "rgb(10, 10, 10)",
+            }}
+          />
+        </div>,
+        document.body,
+      )}
+
+      {/* アイコンオーバーレイ - React Portal でbody直下にレンダリング */}
+      {createPortal(
+        <div
+          className={`fixed inset-0 z-70 flex items-center justify-center pointer-events-none transition-opacity duration-200 ${
+            iconPhase !== "idle" ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          <div className="relative w-32 h-32">
+            {/* 太陽アイコン（大）- ライトモードへ切り替え時に表示（下から上へ） */}
+            <SunIcon
+              strokeWidth={1.25}
+              className={`absolute inset-0 w-full h-full text-foreground transition-all duration-300 ease-out ${
+                !isDark && iconPhase === "enter"
+                  ? "translate-y-0 opacity-100"
+                  : !isDark && iconPhase === "exit"
+                    ? "-translate-y-full opacity-0"
+                    : isDark && iconPhase === "exit"
+                      ? "translate-y-full opacity-0"
+                      : "translate-y-full opacity-0"
+              }`}
+            />
+
+            {/* 月アイコン（大）- ダークモードへ切り替え時に表示（上から下へ） */}
+            <MoonIcon
+              strokeWidth={1.25}
+              className={`absolute inset-0 w-full h-full text-foreground transition-all duration-300 ease-out ${
+                isDark && iconPhase === "enter"
+                  ? "translate-y-0 opacity-100"
+                  : isDark && iconPhase === "exit"
+                    ? "translate-y-full opacity-0"
+                    : !isDark && iconPhase === "exit"
+                      ? "-translate-y-full opacity-0"
+                      : "-translate-y-full opacity-0"
+              }`}
+            />
+          </div>
+        </div>,
+        document.body,
+      )}
+
+      {/* トグルボタン */}
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={toggleTheme}
+        disabled={isAnimating}
+        className="relative w-10 h-10 rounded-full flex items-center justify-center hover:bg-muted transition-colors disabled:cursor-not-allowed z-50"
+        aria-label="テーマを切り替える"
+      >
+        <div className="relative w-5 h-5 overflow-hidden">
+          {/* 太陽アイコン（小） */}
+          <SunIcon
+            className={`absolute inset-0 w-full h-full text-foreground transition-all duration-300 ease-out ${
+              isDark ? "translate-y-full opacity-0" : "translate-y-0 opacity-100"
+            }`}
+          />
+
+          {/* 月アイコン（小） */}
+          <MoonIcon
+            className={`absolute inset-0 w-full h-full text-foreground transition-all duration-300 ease-out ${
+              isDark ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0"
+            }`}
+          />
+        </div>
+      </button>
+    </>
+  );
+}

--- a/src/components/icons/MoonIcon.tsx
+++ b/src/components/icons/MoonIcon.tsx
@@ -1,0 +1,22 @@
+interface MoonIconProps {
+  strokeWidth?: number;
+  className?: string;
+}
+
+export function MoonIcon({ strokeWidth = 2, className = "" }: MoonIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}

--- a/src/components/icons/SunIcon.tsx
+++ b/src/components/icons/SunIcon.tsx
@@ -1,0 +1,30 @@
+interface SunIconProps {
+  strokeWidth?: number;
+  className?: string;
+}
+
+export function SunIcon({ strokeWidth = 2, className = "" }: SunIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,0 +1,2 @@
+export { MoonIcon } from "./MoonIcon";
+export { SunIcon } from "./SunIcon";


### PR DESCRIPTION
## 概要
- テーマ切り替え時に波エフェクトとアイコンカットインアニメーションを追加
- ThemeToggleAnimatedコンポーネントを新規作成し、Header.astroに統合
- SunIcon/MoonIconを再利用可能なコンポーネントとして抽出

## 機能詳細
### 波エフェクト
- ライトモード→ダークモード: 右上から左下へ展開
- ダークモード→ライトモード: 左下から右上へ展開
- cubic-bezier(0.16, 1, 0.3, 1)で急減速イージング

### アイコンカットイン
- 太陽（ライトモード）: 下から上へ
- 月（ダークモード）: 上から下へ

### 技術的な実装
- React Portalでオーバーレイをbody直下にレンダリング
- z-index: 波(z-60) < アイコン(z-70)でHeader(z-50)より前面に表示

## Test plan
- [x] テーマ切り替えボタンをクリックしてアニメーションが動作することを確認
- [x] ライト→ダーク、ダーク→ライトの両方向で波エフェクトが正しい方向から展開されることを確認
- [x] アイコンカットインが縦方向に動作することを確認
- [x] ページリロード後もテーマが永続化されていることを確認
- [ ] モバイル・デスクトップ両方で動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revamped theme toggle with animated wave overlay effect and smooth icon transitions when switching between light and dark modes.
  * Enhanced visual feedback during theme transitions for improved user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->