### PR TITLE
💄 ScrapboxカードのホバーエフェクトをPostカードと統一

### DIFF
--- a/src/components/scrapbox/ScrapboxCard.tsx
+++ b/src/components/scrapbox/ScrapboxCard.tsx
@@ -22,12 +22,9 @@ export function ScrapboxCard({ page, className, isActive = true }: ScrapboxCardP
       data-testid="scrapbox-card"
     >
       <Card
-        className={cn(
-          "h-full overflow-hidden transition-all duration-200 hover:shadow-md",
-          className,
-        )}
+        className={cn("h-full overflow-hidden transition-colors hover:bg-accent/50!", className)}
       >
-        <div className="relative aspect-4/3 w-full overflow-hidden bg-muted">
+        <div className="relative aspect-4/3 w-full overflow-hidden">
           {page.imageUrl ? (
             <img
               ref={ref}

--- a/src/components/scrapbox/ScrapboxCardList.tsx
+++ b/src/components/scrapbox/ScrapboxCardList.tsx
@@ -108,9 +108,8 @@ function ScrapboxCardListInner({ project, limit, className }: ScrapboxCardListPr
             rel="noopener noreferrer"
             className={cn(
               "shrink-0 w-56 p-4",
-              "rounded-lg border border-order",
-              "bg-card/50 hover:bg-card hover:border-border",
-              "transition-all duration-200",
+              "rounded-lg border",
+              "bg-card transition-colors hover:bg-accent/50",
               "group/card",
               "flex flex-col h-40",
             )}


### PR DESCRIPTION
## 概要
- ScrapboxカードのホバーエフェクトをPostカードと同じ `hover:bg-accent/50` に変更
- トップページで使用されている `ScrapboxCardList` と、別コンポーネント `ScrapboxCard` の両方を修正

## テスト項目
- [x] トップページでScrapboxカードにホバーした際、背景色が変わることを確認
- [x] Postカードと同じホバーエフェクトになっていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrapbox card hover effects to use semi-transparent accent background styling instead of shadow effects
  * Simplified card styling with cleaner borders and color-based transitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->