### PR TITLE
🔒 CI/DeployにTakumi Guardレジストリプロキシを設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  npm_config_registry: https://npm.flatt.tech
+
 jobs:
   # Lintチェック
   lint:
@@ -27,6 +30,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
@@ -47,6 +52,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Format check
@@ -67,6 +74,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Sync Astro types
@@ -89,6 +98,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
@@ -109,6 +120,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Sync Astro types
@@ -136,6 +149,8 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright browsers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  npm_config_registry: https://npm.flatt.tech
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,6 +35,8 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
+      - name: Configure Takumi Guard auth
+        run: echo "//npm.flatt.tech/:_authToken=${{ secrets.TAKUMI_GUARD_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Summary
- サプライチェーン攻撃対策として、CI/Deployワークフローの`pnpm install`をFlatt Security Takumi Guard (`npm.flatt.tech`) 経由に変更
- ワークフロー最上位の`env`で`npm_config_registry`を設定し、全ジョブに認証ステップを追加
- 対象: ci.yml（6ジョブ）、deploy.yml（1ジョブ）

## Test plan
- [x] CIが`npm.flatt.tech`経由でパッケージ取得できることを確認
- [x] `TAKUMI_GUARD_TOKEN`シークレットが正しく認証に使われることを確認
- [x] `--frozen-lockfile`によるlockfile整合性チェックが引き続き動作することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve build infrastructure and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->