### PR TITLE
🔒 Scrapbox API Proxy のセキュリティ境界を強化 (テスト追加 + 手動検証 docs)

### DIFF
--- a/docs/security/penetration-checklist.md
+++ b/docs/security/penetration-checklist.md
@@ -12,7 +12,8 @@ Cloudflare Pages Functions で提供している Scrapbox API Proxy (`/api/pages
 
 - 対象環境の URL を環境変数で切り替える:
   ```shell
-  export BASE_URL="https://kjr020.pages.dev"          # Preview / 本番
+  export BASE_URL="https://kjr020.dev"                # 本番 (カスタムドメイン)
+  # export BASE_URL="https://kjr020.pages.dev"         # Preview / Cloudflare Pages デフォルト
   # export BASE_URL="http://localhost:8788"            # wrangler pages dev
   export PROJECT="KJR020"
   ```
@@ -42,17 +43,18 @@ Cloudflare Pages Functions で提供している Scrapbox API Proxy (`/api/pages
 
 | # | コマンド | 期待レスポンス |
 |---|---|---|
-| 2-1 | `curl -i -H "Origin: https://kjr020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: https://kjr020.github.io` + `Vary: Origin` |
+| 2-1 | `curl -i -H "Origin: https://kjr020.dev" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: https://kjr020.dev` + `Vary: Origin` |
 | 2-2 | `curl -i -H "Origin: https://kjr020.pages.dev" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: https://kjr020.pages.dev` |
 | 2-3 | `curl -i -H "Origin: http://localhost:4321" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: http://localhost:4321` |
 | 2-4 | `curl -i "$BASE_URL/api/knowledge/$PROJECT"` (Origin なし) | `Access-Control-Allow-Origin` ヘッダが**付かない** |
 | 2-5 | `curl -i -H "Origin: null" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
 | 2-6 | `curl -i -H "Origin: file://" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
-| 2-7 | `curl -i -H "Origin: https://kjr020.github.io/" "$BASE_URL/api/knowledge/$PROJECT"` (末尾スラッシュ) | `Access-Control-Allow-Origin` なし |
-| 2-8 | `curl -i -H "Origin: https://KJR020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` (大文字違い) | `Access-Control-Allow-Origin` なし |
-| 2-9 | `curl -i -H "Origin: https://kjr020.github.io.evil.com" "$BASE_URL/api/knowledge/$PROJECT"` (サブドメイン偽装) | `Access-Control-Allow-Origin` なし |
-| 2-10 | `curl -i -H "Origin: http://kjr020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` (http スキーム) | `Access-Control-Allow-Origin` なし |
+| 2-7 | `curl -i -H "Origin: https://kjr020.dev/" "$BASE_URL/api/knowledge/$PROJECT"` (末尾スラッシュ) | `Access-Control-Allow-Origin` なし |
+| 2-8 | `curl -i -H "Origin: https://KJR020.dev" "$BASE_URL/api/knowledge/$PROJECT"` (大文字違い) | `Access-Control-Allow-Origin` なし |
+| 2-9 | `curl -i -H "Origin: https://kjr020.dev.evil.com" "$BASE_URL/api/knowledge/$PROJECT"` (サブドメイン偽装) | `Access-Control-Allow-Origin` なし |
+| 2-10 | `curl -i -H "Origin: http://kjr020.dev" "$BASE_URL/api/knowledge/$PROJECT"` (http スキーム) | `Access-Control-Allow-Origin` なし |
 | 2-11 | `curl -i -H "Origin: http://localhost.evil.com" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
+| 2-12 | `curl -i -H "Origin: https://kjr020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` (廃止された旧本番ドメイン) | `Access-Control-Allow-Origin` なし |
 
 ### 3. Secret 非露出 (K-1, K-3)
 

--- a/docs/security/penetration-checklist.md
+++ b/docs/security/penetration-checklist.md
@@ -1,0 +1,112 @@
+# Scrapbox API Proxy 手動検証チェックリスト
+
+Cloudflare Pages Functions で提供している Scrapbox API Proxy (`/api/pages/:project` / `/api/knowledge/:project`) のセキュリティ境界を、**実 HTTP リクエスト**で定期的に確認するためのチェックリスト。
+
+## 位置付け
+
+- Vitest では `fetch` をモックした単体テストでセキュリティ観点を検証している (`functions/**/*.test.ts`)。
+- このチェックリストは「実際の Cloudflare Edge (Preview / 本番) でも同じ挙動になっているか」を確認する**補完的な手動検証**。
+- 自動スキャナ (OWASP ZAP / nuclei / Burp 等) は**使わない**方針。チェックリスト化することで差分をレビューしやすくする。
+
+## 前提
+
+- 対象環境の URL を環境変数で切り替える:
+  ```shell
+  export BASE_URL="https://kjr020.pages.dev"          # Preview / 本番
+  # export BASE_URL="http://localhost:8788"            # wrangler pages dev
+  export PROJECT="KJR020"
+  ```
+- `-i` で**レスポンスヘッダを必ず確認**する (ステータス・`Cache-Control`・`Access-Control-Allow-Origin`)。
+- 実行時は**本番ユーザーのセッション Cookie を絶対に送らない** (`-b` / `--cookie` を使わない)。
+
+## チェック項目
+
+### 1. プロジェクト名バリデーション (K-2)
+
+実装: `validateProject()` は `/^[\w-]+$/` + 1〜64 文字で制限。
+
+| # | コマンド | 期待レスポンス |
+|---|---|---|
+| 1-1 | `curl -i "$BASE_URL/api/pages/$PROJECT"` | `200 OK`、`Content-Type: application/json` |
+| 1-2 | `curl -i "$BASE_URL/api/pages/..%2f..%2fetc"` | `400 Bad Request`、body に Scrapbox の内部情報が含まれない |
+| 1-3 | `curl -i --path-as-is "$BASE_URL/api/pages/../../etc/passwd"` | `400` か `404` (Pages のルーターに吸収される)、Scrapbox API には到達しない |
+| 1-4 | `curl -i "$BASE_URL/api/pages/%2e%2e%2fetc"` | `400 Bad Request` |
+| 1-5 | `curl -i "$BASE_URL/api/pages/foo%00bar"` | `400 Bad Request` (NULL バイト) |
+| 1-6 | `LONG=$(printf 'a%.0s' {1..10000}); curl -i "$BASE_URL/api/pages/$LONG"` | `400` もしくは `414` (URI Too Long)。500 は NG |
+| 1-7 | `curl -i "$BASE_URL/api/pages/$(printf 'a%.0s' {1..64})"` | `200` or `404` (Upstream 次第)。**`400` で落ちないこと** |
+| 1-8 | `curl -i "$BASE_URL/api/pages/$(printf 'a%.0s' {1..65})"` | `400 Bad Request` |
+
+### 2. CORS ホワイトリスト (K-9)
+
+実装: `getAllowedOrigin()` は本番 2 ドメイン + `http://localhost:*` のみを許可。
+
+| # | コマンド | 期待レスポンス |
+|---|---|---|
+| 2-1 | `curl -i -H "Origin: https://kjr020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: https://kjr020.github.io` + `Vary: Origin` |
+| 2-2 | `curl -i -H "Origin: https://kjr020.pages.dev" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: https://kjr020.pages.dev` |
+| 2-3 | `curl -i -H "Origin: http://localhost:4321" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin: http://localhost:4321` |
+| 2-4 | `curl -i "$BASE_URL/api/knowledge/$PROJECT"` (Origin なし) | `Access-Control-Allow-Origin` ヘッダが**付かない** |
+| 2-5 | `curl -i -H "Origin: null" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
+| 2-6 | `curl -i -H "Origin: file://" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
+| 2-7 | `curl -i -H "Origin: https://kjr020.github.io/" "$BASE_URL/api/knowledge/$PROJECT"` (末尾スラッシュ) | `Access-Control-Allow-Origin` なし |
+| 2-8 | `curl -i -H "Origin: https://KJR020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` (大文字違い) | `Access-Control-Allow-Origin` なし |
+| 2-9 | `curl -i -H "Origin: https://kjr020.github.io.evil.com" "$BASE_URL/api/knowledge/$PROJECT"` (サブドメイン偽装) | `Access-Control-Allow-Origin` なし |
+| 2-10 | `curl -i -H "Origin: http://kjr020.github.io" "$BASE_URL/api/knowledge/$PROJECT"` (http スキーム) | `Access-Control-Allow-Origin` なし |
+| 2-11 | `curl -i -H "Origin: http://localhost.evil.com" "$BASE_URL/api/knowledge/$PROJECT"` | `Access-Control-Allow-Origin` なし |
+
+### 3. Secret 非露出 (K-1, K-3)
+
+実装: レスポンス body / ヘッダに `SCRAPBOX_SID` / `connect.sid` の値を出さない。Scrapbox の `descriptions` 原文も knowledge API には載せない。
+
+| # | コマンド | 期待レスポンス |
+|---|---|---|
+| 3-1 | `curl -s "$BASE_URL/api/pages/$PROJECT" \| grep -i 'connect\.sid\|SCRAPBOX_SID\|Set-Cookie'` | **何もヒットしない** |
+| 3-2 | `curl -sI "$BASE_URL/api/pages/$PROJECT" \| grep -i 'Set-Cookie'` | **何もヒットしない** (Proxy は Cookie を中継しない) |
+| 3-3 | `curl -s "$BASE_URL/api/knowledge/$PROJECT" \| jq '.pages[0] \| keys'` | `["hashtags", "id", "linesCount", "linked", "title", "updated*", "views"]` のみ (descriptions 原文が含まれない) |
+| 3-4 | 故意に 401 を誘発するため、Cloudflare 管理画面で `SCRAPBOX_SID` を一時的に無効化した Preview で `curl -i "$BASE_URL/api/pages/$PROJECT"` を叩く | `5xx`、body は `{"error":"Internal server error"}` 等の**汎用メッセージ**のみ。内部スタックや SID 値が漏れていないこと |
+
+### 4. Cache-Control (K-10)
+
+実装: 成功 2xx は `public, max-age=300`、エラー 4xx/5xx は `no-store`。
+
+| # | コマンド | 期待レスポンス |
+|---|---|---|
+| 4-1 | `curl -sI "$BASE_URL/api/pages/$PROJECT" \| grep -i '^Cache-Control:'` | `public, max-age=300` |
+| 4-2 | `curl -sI "$BASE_URL/api/pages/../../etc" \| grep -i '^Cache-Control:'` | `no-store` |
+| 4-3 | `curl -sI "$BASE_URL/api/knowledge/$PROJECT" \| grep -i '^Cache-Control:'` | `public, max-age=300` |
+| 4-4 | `curl -sI "$BASE_URL/api/knowledge/..%2f..%2fetc" \| grep -i '^Cache-Control:'` | `no-store` |
+
+### 5. タイムアウト / 並列度 (K-8)
+
+実装: `knowledge-proxy.ts` に `FETCH_TIMEOUT_MS = 10_000`、`MAX_CONCURRENCY = 3`。
+
+| # | コマンド | 期待挙動 |
+|---|---|---|
+| 5-1 | ページ数が 100 を超えるプロジェクトに対して `time curl -s "$BASE_URL/api/knowledge/$PROJECT" -o /dev/null` | Upstream 応答 × (count / 100 ÷ 3) 相当で完了。固定 10s で打ち切られていないこと |
+| 5-2 | Cloudflare 管理画面で `SCRAPBOX_SID` を無効化した Preview に対して 5-1 と同様に実行 | 10 秒以内にタイムアウトで 5xx。30 秒以上待たないこと |
+| 5-3 | 大量の同時リクエスト (DoS 的挙動の確認のみ、本番には実行しない): `seq 20 \| xargs -P 10 -I{} curl -s -o /dev/null -w '%{http_code}\n' "$BASE_URL/api/knowledge/$PROJECT"` | Cloudflare のデフォルト Rate Limit / 同時実行枠で 200/429 が混在する想定。5xx が連発する場合は要調査 |
+
+> [!WARNING]
+> 5-3 の並列負荷テストは Preview 環境のみに実行する。本番環境には実施しない。
+
+### 6. HTTP メソッド
+
+実装: `onRequestGet` のみ export しているため、他メソッドは Cloudflare Pages Functions 側で自動的に 405 相当になる。
+
+| # | コマンド | 期待レスポンス |
+|---|---|---|
+| 6-1 | `curl -i -X POST "$BASE_URL/api/pages/$PROJECT"` | `405 Method Not Allowed` |
+| 6-2 | `curl -i -X PUT "$BASE_URL/api/knowledge/$PROJECT"` | `405 Method Not Allowed` |
+| 6-3 | `curl -i -X DELETE "$BASE_URL/api/knowledge/$PROJECT"` | `405 Method Not Allowed` |
+
+## 実行タイミング
+
+- **リリース前**: `feature/*` → `main` のマージ前 Preview URL に対して 1〜6 を全項目実行。
+- **定期**: 四半期ごと、もしくは CORS / バリデーション周りの変更があった PR 時。
+- **結果の記録**: 異常があった場合のみ Issue として残す。正常結果は記録不要。
+
+## 関連
+
+- 実装: `functions/_lib/cms-proxy.ts`、`functions/_lib/knowledge-proxy.ts`、`functions/_lib/http.ts`
+- 単体テスト: `functions/_lib/*.test.ts`、`functions/api/**/*.test.ts`
+- セキュリティ要件 ID: K-1 (Secret 非露出), K-2 (project バリデーション), K-3 (descriptions 原文非露出), K-8 (並列度 3 / timeout 10s), K-9 (CORS 制限), K-10 (Cache-Control)

--- a/functions/_lib/cms-proxy.test.ts
+++ b/functions/_lib/cms-proxy.test.ts
@@ -56,6 +56,44 @@ describe("validateProject", () => {
   it("空文字を拒否する", () => {
     expect(validateProject("")).toBe(false);
   });
+
+  // --- Pentest hardening: path traversal / control chars / DoS ---
+  it("URL エンコードされたパストラバーサル (%2e%2e%2f) を拒否する", () => {
+    expect(validateProject("%2e%2e%2fetc")).toBe(false);
+  });
+  it("URL エンコードされたパストラバーサル (大文字 %2E%2E/) を拒否する", () => {
+    expect(validateProject("%2E%2E%2Fetc")).toBe(false);
+  });
+  it("NULL 文字 (\\0) を含むプロジェクト名を拒否する", () => {
+    expect(validateProject("abc\u0000def")).toBe(false);
+  });
+  it("改行文字 (\\n) を含むプロジェクト名を拒否する", () => {
+    expect(validateProject("abc\ndef")).toBe(false);
+  });
+  it("キャリッジリターン (\\r) を含むプロジェクト名を拒否する", () => {
+    expect(validateProject("abc\rdef")).toBe(false);
+  });
+  it("極端に長いプロジェクト名 (10KB) を拒否する", () => {
+    const huge = "a".repeat(10_000);
+    expect(validateProject(huge)).toBe(false);
+  });
+  it("境界ちょうど (64 文字) は許可する", () => {
+    expect(validateProject("a".repeat(64))).toBe(true);
+  });
+  it("境界超え (65 文字) は拒否する", () => {
+    expect(validateProject("a".repeat(65))).toBe(false);
+  });
+  it("ドット (.) 単独を拒否する", () => {
+    expect(validateProject(".")).toBe(false);
+    expect(validateProject("..")).toBe(false);
+  });
+  it("クエリ文字 (?, &, =) を拒否する", () => {
+    expect(validateProject("proj?x=1")).toBe(false);
+    expect(validateProject("proj&bar")).toBe(false);
+  });
+  it("スペースを含むプロジェクト名を拒否する", () => {
+    expect(validateProject("my project")).toBe(false);
+  });
 });
 
 describe("fetchPages", () => {

--- a/functions/_lib/cms-proxy.ts
+++ b/functions/_lib/cms-proxy.ts
@@ -2,6 +2,11 @@ import type { ScrapboxApiResponse, ScrapboxApiPage } from "./types";
 
 const UPSTREAM_BASE = "https://scrapbox.io/api/pages";
 const PROJECT_NAME_PATTERN = /^[\w-]+$/;
+/**
+ * プロジェクト名の最大長。Scrapbox 公式の実際のプロジェクト名は十数文字オーダーで収まるため
+ * 64 文字を上限とする。極端に長い入力 (数 KB 等) での DoS / ログ肥大化を防ぐための境界。
+ */
+const PROJECT_NAME_MAX_LENGTH = 64;
 
 /** Proxy の出力型（フロントエンドとの契約） */
 export interface PageData {
@@ -23,6 +28,8 @@ export type ProxyResult =
     };
 
 export function validateProject(project: string): boolean {
+  if (typeof project !== "string") return false;
+  if (project.length === 0 || project.length > PROJECT_NAME_MAX_LENGTH) return false;
   return PROJECT_NAME_PATTERN.test(project);
 }
 

--- a/functions/_lib/http.test.ts
+++ b/functions/_lib/http.test.ts
@@ -1,106 +1,157 @@
 /** @vitest-environment node */
+/**
+ * http.ts のユニットテスト。
+ *
+ * 設計方針: 同値分割 (Equivalence Class Partitioning) + 境界値分析 (BVA) で入力空間を分類し、
+ * 各クラスに最低1件のテストを置く。異常系はクラス単位で `it.each` を使って羅列を避ける。
+ *
+ * 入力クラス (getAllowedOrigin):
+ *   [A] Origin ヘッダ欠落
+ *   [B] ホワイトリスト完全一致 (正常系)
+ *   [C] localhost 特例 (正常系・プレフィックスマッチ)
+ *   [D] ホワイトリストに類似するが不一致 (境界・異常系)
+ *   [E] localhost に類似するが不一致 (境界・異常系)
+ *   [F] 特殊値 (異常系)
+ *
+ * 入力クラス (jsonResponse):
+ *   [G] status → Cache-Control
+ *   [H] Origin → CORS ヘッダ
+ *   [I] 常に付与されるヘッダ
+ */
 import { describe, expect, it } from "vitest";
 import { getAllowedOrigin, jsonResponse } from "./http";
 
-function reqWith(origin?: string | null): Request {
+/** Origin ヘッダを持った (または持たない) Request を生成 */
+function reqWith(origin?: string): Request {
   const headers = new Headers();
-  if (origin !== undefined && origin !== null) headers.set("Origin", origin);
+  if (origin !== undefined) headers.set("Origin", origin);
   return new Request("https://kjr020.pages.dev/api/test", { headers });
 }
 
 describe("getAllowedOrigin", () => {
-  it("本番ドメイン (kjr020.dev) をそのまま返す", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.dev"))).toBe("https://kjr020.dev");
+  describe("[A] Origin ヘッダ欠落", () => {
+    it("Origin ヘッダが無ければ null を返す", () => {
+      expect(getAllowedOrigin(reqWith())).toBeNull();
+    });
   });
 
-  it("Cloudflare Pages プレビュー (pages.dev) をそのまま返す", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.pages.dev"))).toBe(
-      "https://kjr020.pages.dev",
-    );
+  describe("[B] ホワイトリスト完全一致 (正常系)", () => {
+    it.each([
+      ["本番カスタムドメイン", "https://kjr020.dev"],
+      ["Cloudflare Pages プレビュー", "https://kjr020.pages.dev"],
+    ])("%s は Origin をそのまま返す (%s)", (_label, origin) => {
+      expect(getAllowedOrigin(reqWith(origin))).toBe(origin);
+    });
   });
 
-  it("廃止された github.io ドメインは拒否する", () => {
-    // GitHub Pages を廃止したので許可リストから外した
-    expect(getAllowedOrigin(reqWith("https://kjr020.github.io"))).toBeNull();
+  describe("[C] localhost 特例 (正常系・プレフィックスマッチ)", () => {
+    it.each([
+      ["Astro dev (4321)", "http://localhost:4321"],
+      ["Vite dev (3000)", "http://localhost:3000"],
+      ["wrangler pages dev (8788)", "http://localhost:8788"],
+    ])("%s は任意ポートを許可する (%s)", (_label, origin) => {
+      expect(getAllowedOrigin(reqWith(origin))).toBe(origin);
+    });
   });
 
-  it("localhost は任意ポートを許可する", () => {
-    expect(getAllowedOrigin(reqWith("http://localhost:4321"))).toBe(
-      "http://localhost:4321",
-    );
-    expect(getAllowedOrigin(reqWith("http://localhost:3000"))).toBe(
-      "http://localhost:3000",
-    );
+  describe("[D] ホワイトリストに類似するが不一致 (境界・異常系)", () => {
+    it.each([
+      ["末尾スラッシュ違い", "https://kjr020.dev/"],
+      ["大文字違い (ホスト)", "https://KJR020.dev"],
+      ["スキーム違い (http)", "http://kjr020.dev"],
+      ["サブドメイン偽装 (*.kjr020.dev.evil.com)", "https://kjr020.dev.evil.com"],
+      ["ポート追加", "https://kjr020.dev:8080"],
+      ["廃止された旧本番 (github.io)", "https://kjr020.github.io"],
+    ])("%s は拒否する (%s)", (_label, origin) => {
+      expect(getAllowedOrigin(reqWith(origin))).toBeNull();
+    });
   });
 
-  it("Origin 欠落時は null", () => {
-    expect(getAllowedOrigin(reqWith())).toBeNull();
+  describe("[E] localhost に類似するが不一致 (境界・異常系)", () => {
+    it.each([
+      ["IPv4 ループバック (127.0.0.1)", "http://127.0.0.1:4321"],
+      ["localhost を接頭辞に含む偽装", "http://localhost.evil.com"],
+      ["IPv6 ループバック", "http://[::1]:4321"],
+    ])("%s は拒否する (%s)", (_label, origin) => {
+      expect(getAllowedOrigin(reqWith(origin))).toBeNull();
+    });
   });
 
-  it("Origin: null (文字列) は拒否する", () => {
-    expect(getAllowedOrigin(reqWith("null"))).toBeNull();
-  });
-
-  it("file:// スキームは拒否する", () => {
-    expect(getAllowedOrigin(reqWith("file://"))).toBeNull();
-  });
-
-  it("末尾スラッシュ付き許可ドメインは拒否する", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.dev/"))).toBeNull();
-  });
-
-  it("サブドメイン偽装 (kjr020.dev.evil.com) は拒否する", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.dev.evil.com"))).toBeNull();
-  });
-
-  it("大文字違いは拒否する (厳密一致)", () => {
-    expect(getAllowedOrigin(reqWith("https://KJR020.dev"))).toBeNull();
-  });
-
-  it("http スキームの本番ドメインは拒否する", () => {
-    expect(getAllowedOrigin(reqWith("http://kjr020.dev"))).toBeNull();
-  });
-
-  it("localhost 以外の 127.0.0.1 は拒否する", () => {
-    // 開発用途は localhost のみを明示的に許可する方針
-    expect(getAllowedOrigin(reqWith("http://127.0.0.1:4321"))).toBeNull();
-  });
-
-  it("localhost を名前に含む偽装ドメインは拒否する", () => {
-    // `startsWith("http://localhost:")` は prefix 厳密一致なので OK
-    expect(getAllowedOrigin(reqWith("http://localhost.evil.com"))).toBeNull();
+  describe("[F] 特殊値 (異常系)", () => {
+    it.each([
+      ["文字列 'null' (iframe 等の特殊 Origin)", "null"],
+      ["file:// スキーム", "file://"],
+      ["data URI", "data:text/html,foo"],
+      ["空文字列", ""],
+    ])("%s は拒否する (%s)", (_label, origin) => {
+      expect(getAllowedOrigin(reqWith(origin))).toBeNull();
+    });
   });
 });
 
 describe("jsonResponse", () => {
-  it("成功時は Cache-Control: public, max-age=300", () => {
-    const res = jsonResponse({ ok: true }, 200, reqWith());
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  describe("[G] status → Cache-Control マッピング", () => {
+    it("成功 (200) は `public, max-age=300` でキャッシュ可", () => {
+      const res = jsonResponse({ ok: true }, 200, reqWith());
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    });
+
+    // エラー系は 400 / 500 の両方で同じ挙動を確認 (status >= 400 の境界)
+    it.each([
+      ["4xx (クライアントエラー)", 400],
+      ["4xx 境界", 404],
+      ["5xx (サーバエラー)", 500],
+      ["5xx 上限", 599],
+    ])("%s は `no-store` でキャッシュしない (status=%d)", (_label, status) => {
+      const res = jsonResponse({ error: "x" }, status, reqWith());
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+    });
+
+    // 3xx も成功側として扱う (現実装は status < 400 でキャッシュ)
+    it("リダイレクト (302) はキャッシュ可 (成功側扱い)", () => {
+      const res = jsonResponse({ location: "/" }, 302, reqWith());
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    });
   });
 
-  it("4xx では Cache-Control: no-store", () => {
-    const res = jsonResponse({ error: "bad" }, 400, reqWith());
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  describe("[H] Origin → CORS ヘッダ", () => {
+    it("許可 Origin では Access-Control-Allow-Origin を反映し Vary: Origin を付与", () => {
+      const res = jsonResponse({ ok: true }, 200, reqWith("https://kjr020.dev"));
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
+      expect(res.headers.get("Vary")).toBe("Origin");
+    });
+
+    it("許可外 Origin では CORS ヘッダを付与しない (fail-closed)", () => {
+      const res = jsonResponse({ ok: true }, 200, reqWith("https://evil.com"));
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      expect(res.headers.get("Vary")).toBeNull();
+    });
+
+    it("Origin ヘッダ無しなら CORS ヘッダを付与しない", () => {
+      const res = jsonResponse({ ok: true }, 200, reqWith());
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("エラー時でも許可 Origin には CORS ヘッダを付ける (ブラウザが body を読めるように)", () => {
+      const res = jsonResponse({ error: "x" }, 500, reqWith("https://kjr020.dev"));
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
+    });
   });
 
-  it("5xx では Cache-Control: no-store", () => {
-    const res = jsonResponse({ error: "server" }, 500, reqWith());
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-  });
+  describe("[I] 常に付与されるヘッダ", () => {
+    it("Content-Type: application/json を必ず付与", () => {
+      const res = jsonResponse({ ok: true }, 200, reqWith());
+      expect(res.headers.get("Content-Type")).toBe("application/json");
+    });
 
-  it("許可 Origin では Access-Control-Allow-Origin + Vary: Origin を付与", () => {
-    const res = jsonResponse({ ok: true }, 200, reqWith("https://kjr020.dev"));
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
-    expect(res.headers.get("Vary")).toBe("Origin");
-  });
+    it("body は JSON 文字列化される", async () => {
+      const res = jsonResponse({ hello: "world" }, 200, reqWith());
+      expect(await res.json()).toEqual({ hello: "world" });
+    });
 
-  it("許可外 Origin では Access-Control-Allow-Origin を付与しない", () => {
-    const res = jsonResponse({ ok: true }, 200, reqWith("https://evil.com"));
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
-  it("Content-Type: application/json を常に付与", () => {
-    const res = jsonResponse({ ok: true }, 200, reqWith());
-    expect(res.headers.get("Content-Type")).toBe("application/json");
+    it("指定した status がそのまま Response に反映される", () => {
+      const res = jsonResponse({ error: "x" }, 418, reqWith());
+      expect(res.status).toBe(418);
+    });
   });
 });

--- a/functions/_lib/http.test.ts
+++ b/functions/_lib/http.test.ts
@@ -1,0 +1,107 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import { getAllowedOrigin, jsonResponse } from "./http";
+
+function reqWith(origin?: string | null): Request {
+  const headers = new Headers();
+  if (origin !== undefined && origin !== null) headers.set("Origin", origin);
+  return new Request("https://kjr020.pages.dev/api/test", { headers });
+}
+
+describe("getAllowedOrigin", () => {
+  it("本番ドメイン (github.io) をそのまま返す", () => {
+    expect(getAllowedOrigin(reqWith("https://kjr020.github.io"))).toBe(
+      "https://kjr020.github.io",
+    );
+  });
+
+  it("本番ドメイン (pages.dev) をそのまま返す", () => {
+    expect(getAllowedOrigin(reqWith("https://kjr020.pages.dev"))).toBe(
+      "https://kjr020.pages.dev",
+    );
+  });
+
+  it("localhost は任意ポートを許可する", () => {
+    expect(getAllowedOrigin(reqWith("http://localhost:4321"))).toBe(
+      "http://localhost:4321",
+    );
+    expect(getAllowedOrigin(reqWith("http://localhost:3000"))).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("Origin 欠落時は null", () => {
+    expect(getAllowedOrigin(reqWith())).toBeNull();
+  });
+
+  it("Origin: null (文字列) は拒否する", () => {
+    expect(getAllowedOrigin(reqWith("null"))).toBeNull();
+  });
+
+  it("file:// スキームは拒否する", () => {
+    expect(getAllowedOrigin(reqWith("file://"))).toBeNull();
+  });
+
+  it("末尾スラッシュ付き許可ドメインは拒否する", () => {
+    expect(getAllowedOrigin(reqWith("https://kjr020.github.io/"))).toBeNull();
+  });
+
+  it("サブドメイン偽装 (github.io.evil.com) は拒否する", () => {
+    expect(
+      getAllowedOrigin(reqWith("https://kjr020.github.io.evil.com")),
+    ).toBeNull();
+  });
+
+  it("大文字違いは拒否する (厳密一致)", () => {
+    expect(getAllowedOrigin(reqWith("https://KJR020.github.io"))).toBeNull();
+  });
+
+  it("http スキームの本番ドメインは拒否する", () => {
+    expect(getAllowedOrigin(reqWith("http://kjr020.github.io"))).toBeNull();
+  });
+
+  it("localhost 以外の 127.0.0.1 は拒否する", () => {
+    // 開発用途は localhost のみを明示的に許可する方針
+    expect(getAllowedOrigin(reqWith("http://127.0.0.1:4321"))).toBeNull();
+  });
+
+  it("localhost を名前に含む偽装ドメインは拒否する", () => {
+    // `startsWith("http://localhost:")` は prefix 厳密一致なので OK
+    expect(getAllowedOrigin(reqWith("http://localhost.evil.com"))).toBeNull();
+  });
+});
+
+describe("jsonResponse", () => {
+  it("成功時は Cache-Control: public, max-age=300", () => {
+    const res = jsonResponse({ ok: true }, 200, reqWith());
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("4xx では Cache-Control: no-store", () => {
+    const res = jsonResponse({ error: "bad" }, 400, reqWith());
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("5xx では Cache-Control: no-store", () => {
+    const res = jsonResponse({ error: "server" }, 500, reqWith());
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("許可 Origin では Access-Control-Allow-Origin + Vary: Origin を付与", () => {
+    const res = jsonResponse({ ok: true }, 200, reqWith("https://kjr020.github.io"));
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://kjr020.github.io",
+    );
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("許可外 Origin では Access-Control-Allow-Origin を付与しない", () => {
+    const res = jsonResponse({ ok: true }, 200, reqWith("https://evil.com"));
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("Content-Type: application/json を常に付与", () => {
+    const res = jsonResponse({ ok: true }, 200, reqWith());
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+  });
+});

--- a/functions/_lib/http.test.ts
+++ b/functions/_lib/http.test.ts
@@ -9,16 +9,19 @@ function reqWith(origin?: string | null): Request {
 }
 
 describe("getAllowedOrigin", () => {
-  it("本番ドメイン (github.io) をそのまま返す", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.github.io"))).toBe(
-      "https://kjr020.github.io",
-    );
+  it("本番ドメイン (kjr020.dev) をそのまま返す", () => {
+    expect(getAllowedOrigin(reqWith("https://kjr020.dev"))).toBe("https://kjr020.dev");
   });
 
-  it("本番ドメイン (pages.dev) をそのまま返す", () => {
+  it("Cloudflare Pages プレビュー (pages.dev) をそのまま返す", () => {
     expect(getAllowedOrigin(reqWith("https://kjr020.pages.dev"))).toBe(
       "https://kjr020.pages.dev",
     );
+  });
+
+  it("廃止された github.io ドメインは拒否する", () => {
+    // GitHub Pages を廃止したので許可リストから外した
+    expect(getAllowedOrigin(reqWith("https://kjr020.github.io"))).toBeNull();
   });
 
   it("localhost は任意ポートを許可する", () => {
@@ -43,21 +46,19 @@ describe("getAllowedOrigin", () => {
   });
 
   it("末尾スラッシュ付き許可ドメインは拒否する", () => {
-    expect(getAllowedOrigin(reqWith("https://kjr020.github.io/"))).toBeNull();
+    expect(getAllowedOrigin(reqWith("https://kjr020.dev/"))).toBeNull();
   });
 
-  it("サブドメイン偽装 (github.io.evil.com) は拒否する", () => {
-    expect(
-      getAllowedOrigin(reqWith("https://kjr020.github.io.evil.com")),
-    ).toBeNull();
+  it("サブドメイン偽装 (kjr020.dev.evil.com) は拒否する", () => {
+    expect(getAllowedOrigin(reqWith("https://kjr020.dev.evil.com"))).toBeNull();
   });
 
   it("大文字違いは拒否する (厳密一致)", () => {
-    expect(getAllowedOrigin(reqWith("https://KJR020.github.io"))).toBeNull();
+    expect(getAllowedOrigin(reqWith("https://KJR020.dev"))).toBeNull();
   });
 
   it("http スキームの本番ドメインは拒否する", () => {
-    expect(getAllowedOrigin(reqWith("http://kjr020.github.io"))).toBeNull();
+    expect(getAllowedOrigin(reqWith("http://kjr020.dev"))).toBeNull();
   });
 
   it("localhost 以外の 127.0.0.1 は拒否する", () => {
@@ -88,10 +89,8 @@ describe("jsonResponse", () => {
   });
 
   it("許可 Origin では Access-Control-Allow-Origin + Vary: Origin を付与", () => {
-    const res = jsonResponse({ ok: true }, 200, reqWith("https://kjr020.github.io"));
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "https://kjr020.github.io",
-    );
+    const res = jsonResponse({ ok: true }, 200, reqWith("https://kjr020.dev"));
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
     expect(res.headers.get("Vary")).toBe("Origin");
   });
 

--- a/functions/_lib/http.ts
+++ b/functions/_lib/http.ts
@@ -8,14 +8,14 @@
 
 /** 本番ドメインとして許可する Origin のホワイトリスト */
 export const ALLOWED_ORIGINS: readonly string[] = [
-  "https://kjr020.github.io",
-  "https://kjr020.pages.dev",
+  "https://kjr020.dev", // 本番カスタムドメイン
+  "https://kjr020.pages.dev", // Cloudflare Pages プレビュー URL
 ];
 
 /**
  * リクエストの Origin ヘッダが許可リストに含まれるかを判定する。
  *
- * - 大文字小文字違いや末尾スラッシュ違いは厳密一致しないので拒否する (例: `https://kjr020.github.io/`)
+ * - 大文字小文字違いや末尾スラッシュ違いは厳密一致しないので拒否する (例: `https://kjr020.dev/`)
  * - `Origin: null` や `Origin: file://` のようなブラウザ特殊値も一致しないため拒否される
  * - 開発用途のため `http://localhost:*` のみ例外的に許可する
  *

--- a/functions/_lib/http.ts
+++ b/functions/_lib/http.ts
@@ -1,0 +1,57 @@
+/**
+ * HTTP レスポンス共通ヘルパー。
+ *
+ * Pages Function のエンドポイント間で CORS / Cache-Control の付与ポリシーを共有するための
+ * 最小限のユーティリティ。個別エンドポイントでのポリシーずれ (例: CORS 未設定 / キャッシュ暴露)
+ * を防ぐために一本化している。
+ */
+
+/** 本番ドメインとして許可する Origin のホワイトリスト */
+export const ALLOWED_ORIGINS: readonly string[] = [
+  "https://kjr020.github.io",
+  "https://kjr020.pages.dev",
+];
+
+/**
+ * リクエストの Origin ヘッダが許可リストに含まれるかを判定する。
+ *
+ * - 大文字小文字違いや末尾スラッシュ違いは厳密一致しないので拒否する (例: `https://kjr020.github.io/`)
+ * - `Origin: null` や `Origin: file://` のようなブラウザ特殊値も一致しないため拒否される
+ * - 開発用途のため `http://localhost:*` のみ例外的に許可する
+ *
+ * @returns 許可された Origin 文字列 / 許可されなければ null
+ */
+export function getAllowedOrigin(request: Request): string | null {
+  const origin = request.headers.get("Origin");
+  if (!origin) return null;
+
+  if (ALLOWED_ORIGINS.includes(origin)) return origin;
+
+  // 開発時の localhost は任意ポートを許可
+  if (origin.startsWith("http://localhost:")) return origin;
+
+  return null;
+}
+
+/**
+ * JSON レスポンスを CORS / Cache-Control ヘッダ付きで生成する。
+ *
+ * - エラー (status >= 400) は `Cache-Control: no-store` で CDN に載せない
+ * - 成功時は `public, max-age=300` で 5 分キャッシュ可
+ * - 許可外 Origin に対しては `Access-Control-Allow-Origin` を付与しない (フェイルクローズ)
+ */
+export function jsonResponse(body: unknown, status: number, request: Request): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    // エラーレスポンスをキャッシュすると回復後も影響するため、成功時のみキャッシュを許可
+    "Cache-Control": status >= 400 ? "no-store" : "public, max-age=300",
+  };
+
+  const allowedOrigin = getAllowedOrigin(request);
+  if (allowedOrigin) {
+    headers["Access-Control-Allow-Origin"] = allowedOrigin;
+    headers["Vary"] = "Origin";
+  }
+
+  return new Response(JSON.stringify(body), { status, headers });
+}

--- a/functions/_lib/knowledge-proxy.test.ts
+++ b/functions/_lib/knowledge-proxy.test.ts
@@ -149,6 +149,29 @@ describe("fetchAllKnowledgePages", () => {
     if (result.ok) return;
     expect(result.code).toBe("network_error");
   });
+
+  // --- Pentest hardening: secret leak / error body ---
+  it("エラー戻り値 (network_error) に connect.sid の値や `SCRAPBOX_SID` 文字列が含まれない", async () => {
+    const secret = "s:super-secret-sid.signature";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    const result = await fetchAllKnowledgePages("KJR020", secret);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("connect.sid");
+    expect(serialized).not.toContain("SCRAPBOX_SID");
+  });
+
+  it("エラー戻り値 (upstream_error 401) に Secret が含まれない", async () => {
+    const secret = "s:super-secret-sid.signature";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("Unauthorized", { status: 401 })),
+    );
+    const result = await fetchAllKnowledgePages("KJR020", secret);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("connect.sid");
+  });
 });
 
 describe("fetchWithConcurrencyLimit", () => {

--- a/functions/api/knowledge/[project].test.ts
+++ b/functions/api/knowledge/[project].test.ts
@@ -90,9 +90,16 @@ describe("GET /api/knowledge/:project", () => {
 
   it("本番ドメイン Origin は CORS で許可される", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
+    const ctx = createContext("KJR020", { origin: "https://kjr020.dev" });
+    const res = await onRequestGet(ctx);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
+  });
+
+  it("廃止された github.io ドメインは CORS で弾かれる", async () => {
+    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", { origin: "https://kjr020.github.io" });
     const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.github.io");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   it("許可外ドメイン Origin は Access-Control-Allow-Origin を付与しない", async () => {
@@ -140,32 +147,32 @@ describe("GET /api/knowledge/:project", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("末尾スラッシュ付きの許可ドメイン (https://kjr020.github.io/) は CORS で弾かれる", async () => {
+  it("末尾スラッシュ付きの許可ドメイン (https://kjr020.dev/) は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://kjr020.github.io/" });
+    const ctx = createContext("KJR020", { origin: "https://kjr020.dev/" });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("サブドメイン偽装 (https://kjr020.github.io.evil.com) は CORS で弾かれる", async () => {
+  it("サブドメイン偽装 (https://kjr020.dev.evil.com) は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", {
-      origin: "https://kjr020.github.io.evil.com",
+      origin: "https://kjr020.dev.evil.com",
     });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("大文字違いの許可ドメイン (https://KJR020.github.io) は CORS で弾かれる", async () => {
+  it("大文字違いの許可ドメイン (https://KJR020.dev) は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://KJR020.github.io" });
+    const ctx = createContext("KJR020", { origin: "https://KJR020.dev" });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   it("http:// スキームの本番ドメインは CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "http://kjr020.github.io" });
+    const ctx = createContext("KJR020", { origin: "http://kjr020.dev" });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });

--- a/functions/api/knowledge/[project].ts
+++ b/functions/api/knowledge/[project].ts
@@ -1,42 +1,10 @@
 import { validateProject } from "../../_lib/cms-proxy";
+import { jsonResponse } from "../../_lib/http";
 import { fetchAllKnowledgePages } from "../../_lib/knowledge-proxy";
 import { logError } from "../../_lib/logger";
 
 interface Env {
   SCRAPBOX_SID: string;
-}
-
-const ALLOWED_ORIGINS = [
-  "https://kjr020.github.io",
-  "https://kjr020.pages.dev",
-];
-
-function getAllowedOrigin(request: Request): string | null {
-  const origin = request.headers.get("Origin");
-  if (!origin) return null;
-
-  if (ALLOWED_ORIGINS.includes(origin)) return origin;
-
-  // Allow localhost in development
-  if (origin.startsWith("http://localhost:")) return origin;
-
-  return null;
-}
-
-function jsonResponse(body: unknown, status: number, request: Request): Response {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    // エラーレスポンスをキャッシュすると回復後も影響するため、成功時のみキャッシュを許可
-    "Cache-Control": status >= 400 ? "no-store" : "public, max-age=300",
-  };
-
-  const allowedOrigin = getAllowedOrigin(request);
-  if (allowedOrigin) {
-    headers["Access-Control-Allow-Origin"] = allowedOrigin;
-    headers["Vary"] = "Origin";
-  }
-
-  return new Response(JSON.stringify(body), { status, headers });
 }
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {

--- a/functions/api/pages/[project].test.ts
+++ b/functions/api/pages/[project].test.ts
@@ -17,7 +17,7 @@ function mockSuccessfulScrapboxFetch() {
             id: "p1",
             title: "page-1",
             image: null,
-            descriptions: ["#設計 memo"],
+            descriptions: ["desc"],
             updated: 1_700_000_000,
             created: 1_700_000_000,
             views: 10,
@@ -34,26 +34,47 @@ function mockSuccessfulScrapboxFetch() {
 
 function createContext(
   project: string,
-  options?: { origin?: string; scrapboxSid?: string },
+  options?: { origin?: string; scrapboxSid?: string; url?: string },
 ) {
   const headers = new Headers();
   if (options?.origin) headers.set("Origin", options.origin);
+  const url = options?.url ?? `https://kjr020.pages.dev/api/pages/${project}`;
   return {
     params: { project },
     env: { SCRAPBOX_SID: options?.scrapboxSid ?? "test-sid" },
-    request: new Request(`https://kjr020.pages.dev/api/knowledge/${project}`, { headers }),
-  // biome-ignore lint/suspicious/noExplicitAny: minimum PagesFunction context for testing
+    request: new Request(url, { headers }),
+    // biome-ignore lint/suspicious/noExplicitAny: minimum PagesFunction context for testing
   } as any;
 }
 
-describe("GET /api/knowledge/:project", () => {
+describe("GET /api/pages/:project", () => {
   it("不正なプロジェクト名 (path traversal) を 400 で拒否する", async () => {
     vi.stubGlobal("fetch", vi.fn());
     const ctx = createContext("../../users");
     const res = await onRequestGet(ctx);
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body).toEqual({ error: "Invalid project name" });
+    expect(await res.json()).toEqual({ error: "Invalid project name" });
+  });
+
+  it("URL エンコードされたパストラバーサル (%2e%2e%2f) を 400 で拒否する", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const ctx = createContext("%2e%2e%2fetc");
+    const res = await onRequestGet(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("制御文字入りのプロジェクト名を 400 で拒否する", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const ctx = createContext("abc\ndef");
+    const res = await onRequestGet(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("極端に長いプロジェクト名 (10KB) を 400 で拒否する", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const ctx = createContext("a".repeat(10_000));
+    const res = await onRequestGet(ctx);
+    expect(res.status).toBe(400);
   });
 
   it("SCRAPBOX_SID 未設定時は 500 を返す", async () => {
@@ -78,48 +99,16 @@ describe("GET /api/knowledge/:project", () => {
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
   });
 
-  it("成功レスポンスには pages/count/projectName が含まれる", async () => {
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020");
-    const res = await onRequestGet(ctx);
-    const body = await res.json();
-    expect(body.projectName).toBe("KJR020");
-    expect(body.count).toBe(1);
-    expect(Array.isArray(body.pages)).toBe(true);
-  });
-
   it("本番ドメイン Origin は CORS で許可される", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", { origin: "https://kjr020.github.io" });
     const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.github.io");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://kjr020.github.io",
+    );
   });
 
-  it("許可外ドメイン Origin は Access-Control-Allow-Origin を付与しない", async () => {
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://evil.example.com" });
-    const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
-  it("localhost Origin は開発用途で許可される", async () => {
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "http://localhost:4321" });
-    const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:4321");
-  });
-
-  it("レスポンスには SCRAPBOX_SID の値が含まれない", async () => {
-    const secret = "s:super-secret-sid.signature";
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { scrapboxSid: secret });
-    const res = await onRequestGet(ctx);
-    const body = await res.text();
-    expect(body).not.toContain(secret);
-  });
-
-  // --- Pentest hardening: CORS edge cases ---
-  it("Origin: null は CORS で弾かれる (Access-Control-Allow-Origin 非付与)", async () => {
+  it("Origin: null は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", { origin: "null" });
     const res = await onRequestGet(ctx);
@@ -133,20 +122,6 @@ describe("GET /api/knowledge/:project", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("Origin ヘッダ欠落時は Access-Control-Allow-Origin を付与しない", async () => {
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020");
-    const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
-  it("末尾スラッシュ付きの許可ドメイン (https://kjr020.github.io/) は CORS で弾かれる", async () => {
-    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://kjr020.github.io/" });
-    const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
-  });
-
   it("サブドメイン偽装 (https://kjr020.github.io.evil.com) は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", {
@@ -156,44 +131,32 @@ describe("GET /api/knowledge/:project", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("大文字違いの許可ドメイン (https://KJR020.github.io) は CORS で弾かれる", async () => {
+  it("末尾スラッシュ付きの許可ドメインは CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://KJR020.github.io" });
+    const ctx = createContext("KJR020", { origin: "https://kjr020.github.io/" });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("http:// スキームの本番ドメインは CORS で弾かれる", async () => {
+  it("localhost Origin は開発用途で許可される", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "http://kjr020.github.io" });
+    const ctx = createContext("KJR020", { origin: "http://localhost:4321" });
     const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "http://localhost:4321",
+    );
   });
 
-  // --- Pentest hardening: project name validation via endpoint ---
-  it("URL エンコードされたパストラバーサル (%2e%2e%2f) を 400 で拒否する", async () => {
-    vi.stubGlobal("fetch", vi.fn());
-    const ctx = createContext("%2e%2e%2fetc");
+  it("レスポンスには SCRAPBOX_SID 値が含まれない", async () => {
+    const secret = "s:super-secret-sid.signature";
+    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
+    const ctx = createContext("KJR020", { scrapboxSid: secret });
     const res = await onRequestGet(ctx);
-    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).not.toContain(secret);
   });
 
-  it("制御文字入りのプロジェクト名を 400 で拒否する", async () => {
-    vi.stubGlobal("fetch", vi.fn());
-    const ctx = createContext("abc\u0000def");
-    const res = await onRequestGet(ctx);
-    expect(res.status).toBe(400);
-  });
-
-  it("極端に長いプロジェクト名 (10KB) を 400 で拒否する", async () => {
-    vi.stubGlobal("fetch", vi.fn());
-    const ctx = createContext("a".repeat(10_000));
-    const res = await onRequestGet(ctx);
-    expect(res.status).toBe(400);
-  });
-
-  // --- Pentest hardening: error body hygiene ---
-  it("エラーレスポンスの body に SCRAPBOX_SID 値が含まれない", async () => {
+  it("エラーレスポンスの body に SCRAPBOX_SID 値 / connect.sid 文字列が含まれない", async () => {
     const secret = "s:super-secret-sid.signature";
     vi.stubGlobal(
       "fetch",
@@ -206,7 +169,7 @@ describe("GET /api/knowledge/:project", () => {
     expect(body).not.toContain("connect.sid");
   });
 
-  it("エラーレスポンスの body には汎用メッセージのみ (内部実装を露出しない)", async () => {
+  it("エラーレスポンスの body は汎用メッセージのみ (内部実装を露出しない)", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(new Response("Unauthorized", { status: 401 })),

--- a/functions/api/pages/[project].test.ts
+++ b/functions/api/pages/[project].test.ts
@@ -101,11 +101,16 @@ describe("GET /api/pages/:project", () => {
 
   it("本番ドメイン Origin は CORS で許可される", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
+    const ctx = createContext("KJR020", { origin: "https://kjr020.dev" });
+    const res = await onRequestGet(ctx);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://kjr020.dev");
+  });
+
+  it("廃止された github.io ドメインは CORS で弾かれる", async () => {
+    vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", { origin: "https://kjr020.github.io" });
     const res = await onRequestGet(ctx);
-    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-      "https://kjr020.github.io",
-    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
   it("Origin: null は CORS で弾かれる", async () => {
@@ -122,10 +127,10 @@ describe("GET /api/pages/:project", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("サブドメイン偽装 (https://kjr020.github.io.evil.com) は CORS で弾かれる", async () => {
+  it("サブドメイン偽装 (https://kjr020.dev.evil.com) は CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
     const ctx = createContext("KJR020", {
-      origin: "https://kjr020.github.io.evil.com",
+      origin: "https://kjr020.dev.evil.com",
     });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
@@ -133,7 +138,7 @@ describe("GET /api/pages/:project", () => {
 
   it("末尾スラッシュ付きの許可ドメインは CORS で弾かれる", async () => {
     vi.stubGlobal("fetch", mockSuccessfulScrapboxFetch());
-    const ctx = createContext("KJR020", { origin: "https://kjr020.github.io/" });
+    const ctx = createContext("KJR020", { origin: "https://kjr020.dev/" });
     const res = await onRequestGet(ctx);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });

--- a/functions/api/pages/[project].ts
+++ b/functions/api/pages/[project].ts
@@ -1,15 +1,9 @@
-import { validateProject, fetchPages } from "../../_lib/cms-proxy";
+import { fetchPages, validateProject } from "../../_lib/cms-proxy";
+import { jsonResponse } from "../../_lib/http";
 import { logError } from "../../_lib/logger";
 
 interface Env {
   SCRAPBOX_SID: string;
-}
-
-function jsonResponse(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
@@ -17,10 +11,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   const scrapboxSid = context.env.SCRAPBOX_SID;
 
   if (!validateProject(project)) {
-    return jsonResponse({ error: "Invalid project name" }, 400);
+    return jsonResponse({ error: "Invalid project name" }, 400, context.request);
   }
   if (!scrapboxSid) {
-    return jsonResponse({ error: "Server misconfigured" }, 500);
+    return jsonResponse({ error: "Server misconfigured" }, 500, context.request);
   }
 
   const { search } = new URL(context.request.url);
@@ -37,8 +31,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     });
     const status =
       result.code === "upstream_error" && result.status ? result.status : 500;
-    return jsonResponse({ error: "Internal server error" }, status);
+    return jsonResponse({ error: "Internal server error" }, status, context.request);
   }
 
-  return jsonResponse(result.pages, 200);
+  return jsonResponse(result.pages, 200, context.request);
 };


### PR DESCRIPTION
## Summary

- Scrapbox API Proxy (`/api/pages/:project`, `/api/knowledge/:project`) のセキュリティ境界を Vitest で網羅的に固め、手動検証用の curl チェックリストを docs 化した。
- 自動スキャナ (ZAP 等) は **使わない** 方針。テスト増強 + 手順書で差分レビューしやすくする。

## 追加したテスト (全 61 件 / 112 → 173)

| ファイル | 追加数 | 観点 |
|---|---:|---|
| `functions/_lib/cms-proxy.test.ts` | +11 | URL エンコード path traversal (`%2e%2e%2f` / `%2E%2E/`)、制御文字 (`\0` / `\n` / `\r`)、長さ境界 (64 / 65 / 10KB)、ドット・スペース・クエリ文字の拒否 |
| `functions/_lib/knowledge-proxy.test.ts` | +2 | エラー戻り値 (network_error / upstream_error 401) に SID 値 / `connect.sid` 文字列が含まれないこと |
| `functions/_lib/http.test.ts` (新規) | +18 | CORS ホワイトリストの厳密一致 (末尾スラッシュ / 大文字違い / サブドメイン偽装 / `http` スキーム / `127.0.0.1` / `localhost.evil.com` 等)、`Cache-Control` ポリシー |
| `functions/api/knowledge/[project].test.ts` | +13 | Origin `null` / `file://` / 欠落 / 許可外を CORS で弾く、長大入力・制御文字を 400 で拒否、エラー body のハイジーン |
| `functions/api/pages/[project].test.ts` (新規) | +17 | 上記と同等観点を pages エンドポイント側でも担保 |

## 修正した不備 (最小限)

既存実装のテスト追加で 2 件の不備が発覚し、最小修正で揃えた:

1. **`GET /api/pages/:project` に CORS / `Cache-Control` が未設定だった**
   - knowledge 側と異なるポリシーが本番にデプロイされていた (K-9, K-10 の不整合)。
   - `functions/_lib/http.ts` に `getAllowedOrigin()` / `jsonResponse()` を切り出し、両エンドポイントで共有することで解消。
2. **`validateProject()` に文字数上限が無く、10KB 級の入力を受理していた**
   - パターン `/^[\w-]+$/` は長さを制限しないため、DoS / ログ肥大化の懸念。
   - `PROJECT_NAME_MAX_LENGTH = 64` を追加。1〜64 文字に制限 (Scrapbox 実プロジェクト名は十数文字オーダー)。

いずれも大きなリファクタではなく、既存挙動を壊さない追加のみ。

## 手動検証 docs

- 追加: `docs/security/penetration-checklist.md`
- 使い方:
  - `BASE_URL` を Preview / 本番の URL に差し替えて、節単位 (プロジェクト名バリデーション / CORS / Secret 非露出 / Cache-Control / タイムアウト / HTTP メソッド) で curl を実行する。
  - 実行タイミング: 主要マージ前の Preview URL に対して、および四半期ごと。
  - 並列負荷テスト (5-3) は **Preview のみ**。本番には実施しない旨を明記。

## セキュリティ要件のカバレッジ

| 要件 ID | 内容 | 検証 |
|---|---|---|
| K-1 | Secret 非露出 | cms-proxy / knowledge-proxy / 両エンドポイントテスト + 手動 3-1〜3-4 |
| K-2 | project バリデーション | cms-proxy / 両エンドポイントテスト + 手動 1-1〜1-8 |
| K-3 | descriptions 原文非露出 | knowledge-proxy テスト + 手動 3-3 |
| K-8 | 並列度 3 / timeout 10s | 既存 `knowledge-proxy.test.ts` の `fetchWithConcurrencyLimit` + 手動 5-1〜5-3 |
| K-9 | CORS 制限 | `http.test.ts` + 両エンドポイントテスト + 手動 2-1〜2-11 |
| K-10 | Cache-Control | `http.test.ts` + 両エンドポイントテスト + 手動 4-1〜4-4 |

## Test plan

- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test:run` 通過 (173/173 tests)
- [x] `pnpm build` 通過
- [ ] Preview デプロイ後、`docs/security/penetration-checklist.md` の 1〜4 節を手動で一回実行する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Enforced CORS origin allowlist validation for API endpoints
  * Prevented sensitive credentials from leaking in error responses
  * Added stricter project name validation with 64-character limit and special character filtering
  * Implemented appropriate cache control headers (`no-store` for errors, extended caching for success)

* **Documentation**
  * Added security verification checklist for manual penetration testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->