### PR TITLE
🔧 本番ドメイン kjr020.dev に更新 + README 全面リニューアル

### DIFF
--- a/.claude/rules/content-structure.md
+++ b/.claude/rules/content-structure.md
@@ -41,8 +41,8 @@ const posts = defineCollection({
 
 ```typescript
 // Good: 既存パターンに合わせた定義
-const newsletters = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./content/newsletters" }),
+const guides = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./content/guides" }),
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),
@@ -50,7 +50,7 @@ const newsletters = defineCollection({
   }),
 });
 
-export const collections = { posts, newsletters };
+export const collections = { posts, guides };
 ```
 
 **注意:** スキーマ変更後は `npx astro sync` を実行して型を再生成する。

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ pnpm typecheck
 
 ## デプロイ
 
-GitHub Pagesにデプロイ
+Cloudflare Pages にデプロイ
 
-https://kjr020.github.io/
+https://kjr020.dev/

--- a/README.md
+++ b/README.md
@@ -1,87 +1,149 @@
 # KJR020's Blog
 
-Astroで構築した個人ブログ
+KJR020の技術ブログ。Astro + Cloudflare Pages で構築し、Scrapbox の知識体系を可視化する Knowledge Graph 機能を備える。
 
-## 技術スタック
+[![CI](https://github.com/KJR020/kjr020.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/KJR020/kjr020.github.io/actions/workflows/ci.yml)
 
-- [Astro](https://astro.build/) - 静的サイトジェネレーター
-- [React](https://react.dev/) - UIコンポーネント
-- [Tailwind CSS](https://tailwindcss.com/) - スタイリング
-- [Biome](https://biomejs.dev/) - Linter / Formatter
-- [Vitest](https://vitest.dev/) - テストフレームワーク
-- [Playwright](https://playwright.dev/) - E2Eテスト
+**https://kjr020.dev/**
+
+## 特徴
+
+### Knowledge Graph
+
+Scrapbox に蓄積した 1,788 ページのハッシュタグ共起関係を [Cytoscape.js](https://js.cytoscape.org/) で可視化。ノードサイズがページ数を反映し、知識の濃淡が一目で分かる。
+
+- タグ共起グラフ + タグ別ページ一覧の 2 ビュー
+- Cloudflare Pages Functions 経由で Scrapbox API を安全に中継（descriptions 原文非公開、CORS 制限、Cache-Control）
+- ハッシュタグは `[...]` 内の URL fragment を除外し `_` をスペースに正規化して抽出
+
+### 全文検索
+
+[Pagefind](https://pagefind.app/) によるクライアントサイド全文検索。`Cmd+K` でコマンドパレットから即座にアクセス可能。
+
+### ブログ機能
+
+- Markdown + Astro Content Collections による記事管理
+- タグ分類 / シンタックスハイライト (Shiki) / Mermaid 図 / コールアウト / リンクカード
+- [Giscus](https://giscus.app/) によるコメント (GitHub Discussions 連携)
+- レスポンシブデザイン + ダークモード
+- sitemap 自動生成
 
 ## アーキテクチャ
 
-詳細な設計方針は [docs/architecture/](docs/architecture/) に記載。
+```mermaid
+graph TB
+    subgraph Browser
+        ASTRO["Astro 静的ページ"]
+        SEARCH["Pagefind 全文検索"]
+        KG["Knowledge Graph<br/>(Cytoscape.js)"]
+    end
 
-## セットアップ
+    subgraph CF["Cloudflare Pages"]
+        STATIC["静的ホスティング"]
+        FN_PAGES["Pages Function<br/>GET /api/pages/:project"]
+        FN_KNOWLEDGE["Pages Function<br/>GET /api/knowledge/:project"]
+    end
+
+    subgraph External
+        SB["Scrapbox API"]
+    end
+
+    ASTRO --> STATIC
+    KG --> FN_KNOWLEDGE
+    FN_PAGES --> SB
+    FN_KNOWLEDGE --> SB
+```
+
+## 技術スタック
+
+| カテゴリ          | 技術                                                                  |
+|---------------|-----------------------------------------------------------------------|
+| フレームワーク       | [Astro](https://astro.build/) 5.x + [React](https://react.dev/) 19    |
+| スタイリング        | [Tailwind CSS](https://tailwindcss.com/) 4                            |
+| 可視化        | [Cytoscape.js](https://js.cytoscape.org/) (Knowledge Graph)           |
+| 検索          | [Pagefind](https://pagefind.app/) (クライアントサイド全文検索)                 |
+| インフラ          | [Cloudflare Pages](https://pages.cloudflare.com/) + Pages Functions   |
+| Lint / Format | [Biome](https://biomejs.dev/)                                         |
+| テスト           | [Vitest](https://vitest.dev/) + [Playwright](https://playwright.dev/) |
+| CI/CD         | GitHub Actions → Cloudflare Pages                                     |
+
+## プロジェクト構成
+
+```text
+src/
+├── components/          # UI コンポーネント (Astro / React)
+│   └── knowledge/       #   Knowledge Graph 関連
+├── content/posts/       # ブログ記事 (Markdown)
+├── hooks/               # React Hooks
+├── layouts/             # ページレイアウト
+├── lib/                 # ユーティリティ
+├── pages/               # ルーティング (ファイルベース)
+├── styles/              # グローバルスタイル
+└── types/               # 型定義
+
+functions/
+├── _lib/                # Proxy 共通ロジック (hashtag parser, http helper)
+└── api/
+    ├── pages/           # Scrapbox ページ一覧 Proxy
+    └── knowledge/       # Knowledge Graph 用全ページ取得 Proxy
+
+docs/
+├── architecture/        # 設計ドキュメント
+└── security/            # セキュリティ検証チェックリスト
+```
+
+<details>
+<summary><strong>開発ガイド</strong></summary>
 
 ### 必要な環境
 
-- Node.js 22.x 以上
-- pnpm
+- Node.js 22.x
+- pnpm 10.x
 
-### インストール
+### セットアップ
 
 ```shell
 pnpm install
 ```
 
-## 使い方
+### コマンド
 
-### 開発サーバーの起動
+| コマンド                 | 説明               |
+|----------------------|--------------------|
+| `pnpm dev`           | Astro 開発サーバー起動 |
+| `pnpm build`         | 本番ビルド            |
+| `pnpm preview`       | ビルド結果のプレビュー      |
+| `pnpm lint`          | Biome Lint         |
+| `pnpm lint:fix`      | Lint 自動修正      |
+| `pnpm format`        | フォーマット             |
+| `pnpm typecheck`     | TypeScript 型チェック  |
+| `pnpm test:run`      | Vitest 実行        |
+| `pnpm test:coverage` | カバレッジ計測          |
+| `pnpm test:e2e`      | Playwright E2E テスト |
 
-```shell
-pnpm dev
-```
+### Cloudflare Pages Functions のローカル実行
 
-### ビルド
-
-```shell
-pnpm build
-```
-
-### プレビュー
-
-```shell
-pnpm preview
-```
-
-### Lint / Format
+Scrapbox API Proxy (`/api/*`) を動かすには `wrangler` が必要:
 
 ```shell
-# Lintの実行
-pnpm lint
-
-# Lintの自動修正
-pnpm lint:fix
-
-# フォーマットの実行
-pnpm format
-
-# フォーマットのチェック
-pnpm format:check
+# Astro dev + Functions を同時に起動
+pnpm dev                             # port 4321
+pnpm exec wrangler pages dev --proxy 4321 --port 8788
+# → http://localhost:8788 でアクセス
 ```
 
-### テスト
+`.dev.vars` に `SCRAPBOX_SID` を設定:
 
 ```shell
-# テストの実行（watchモード）
-pnpm test
-
-# テストの実行（1回のみ）
-pnpm test:run
+SCRAPBOX_SID=your-connect-sid-value
 ```
 
-### 型チェック
-
-```shell
-pnpm typecheck
-```
+</details>
 
 ## デプロイ
 
-Cloudflare Pages にデプロイ
+Cloudflare Pages に自動デプロイ。`main` ブランチへの push で GitHub Actions → Cloudflare Pages にビルド・デプロイされる。
 
-https://kjr020.dev/
+## ライセンス
+
+記事コンテンツ (`src/content/`) の著作権は著者に帰属します。ソースコードは自由に参照してください。

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,7 +19,7 @@ const calloutIcons = {
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://kjr020.github.io",
+  site: "https://kjr020.dev",
   build: {
     format: "directory",
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/KJR020/kjr020.github.io/issues"
   },
-  "homepage": "https://kjr020.github.io/",
+  "homepage": "https://kjr020.dev/",
   "dependencies": {
     "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.6.1",


### PR DESCRIPTION
## Summary

### 1. README 全面リニューアル
ポートフォリオ閲覧者向けに「何が面白いか」を先頭に配置する構成に変更。

- **特徴セクション**: Knowledge Graph / 全文検索 / ブログ機能を先頭に
- **Mermaid アーキテクチャ図**: Browser → Cloudflare Pages → Scrapbox API の全体像
- **技術スタック**: テーブル形式でカテゴリ分け
- **開発ガイド**: `<details>` 折りたたみ (外部閲覧者はスキップ可)
- **プロジェクト構成**: `src/` + `functions/` + `docs/` のディレクトリツリー

### 2. 本番ドメイン更新
- `README.md`: デプロイ先を Cloudflare Pages に、URL を `https://kjr020.dev/` に
- `package.json`: `homepage` を `https://kjr020.dev/` に
- `astro.config.mjs`: `site` を `https://kjr020.dev` に (sitemap 生成 URL に影響)

### 3. newsletters 残存参照の削除
- `.claude/rules/content-structure.md`: 廃止済み `newsletters` コレクション例示を `guides` に差し替え

## Test plan
- [x] `pnpm test:run` (189 passed)
- [x] `pnpm typecheck`
- [x] `pnpm build` (101 pages)