### PR TITLE
✅ テストカバレッジ計測の整備とゲート80%化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run coverage
-        run: pnpm test:coverage
+        run: pnpm test:coverage:check
 
   # ビルドチェック
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 # Claude Code
 .claude/settings.local.json
 .claude/projects/
+.claude/worktrees/
 .claude/scheduled_tasks.lock
 **/CLAUDE.md
 !/CLAUDE.md

--- a/.kiro/specs/20260505-test-coverage-measurement/design.md
+++ b/.kiro/specs/20260505-test-coverage-measurement/design.md
@@ -1,0 +1,206 @@
+# Design Document: test-coverage-measurement
+
+## Table of Contents
+
+| Section | What You'll Learn |
+|---------|-------------------|
+| [Overview](#overview) | カバレッジ測定の設計方針と非目標を示す |
+| [Architecture](#architecture) | 既存の Vitest/CI 構成にどう組み込むかを示す |
+| [System Flows](#system-flows) | report-only と quality gate の実行フローを示す |
+| [Requirements Traceability](#requirements-traceability) | 各要件と設計要素の対応を示す |
+| [Components and Interfaces](#components-and-interfaces) | 変更・参照対象の設定ファイルと契約を整理する |
+| [Verification](#verification) | 実測済みコマンドと期待結果を記録する |
+
+## Overview
+
+**Purpose**: この設計は、Vitest の v8 coverage provider を使って、既存の単体・統合テストからロジック中心のカバレッジを再現可能に測定する。
+
+**Users**: 開発者が実装前後のテストカバレッジを確認し、未カバー箇所の優先順位を決めるために利用する。
+
+**Impact**: 既存の `vitest.config.ts`, `package.json`, `.github/workflows/ci.yml` を中心に、測定専用コマンドと閾値チェックコマンドの責務を明確にする。`test:coverage:report` を日常測定用、`test:coverage:check` を品質ゲート用として追加する。
+
+### Goals
+
+- カバレッジ測定結果をローカルで再現可能に取得できる
+- HTML/LCOV レポートを生成できる
+- report-only と quality gate の exit code の意味を分離する
+- CI 上の coverage job の意図を明確にする
+
+### Non-Goals
+
+- Playwright E2E/snapshot test の coverage 統合
+- UI コンポーネント全体の網羅率を coverage gate に含めること
+- 初回から coverage threshold を必須 gate にすること
+- カバレッジを上げるためだけの低価値テスト追加
+
+## Architecture
+
+### Existing Architecture Analysis
+
+現在の構成:
+
+- `package.json`
+  - `test:run`: `vitest run`
+  - `test:coverage`: `vitest run --coverage`
+- `vitest.config.ts`
+  - `coverage.provider`: `v8`
+  - `coverage.reporter`: `text`, `html`, `lcov`
+  - `coverage.include`: Functions, lib, hooks, knowledge format
+  - `coverage.thresholds`: lines/functions/statements/branches 80%
+- `.github/workflows/ci.yml`
+  - `test` job で `pnpm test:run --passWithNoTests`
+  - `coverage` job で `pnpm test:coverage`
+  - `coverage` job は `continue-on-error: true`
+
+維持する制約:
+
+- 測定対象はロジック中心に限定する。
+- coverage artifacts は `coverage/` に生成し、`.gitignore` で除外する。
+- CI の初期運用では coverage failure を blocking gate にしない。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph TB
+    Dev[Developer] --> Script[package.json scripts]
+    CI[GitHub Actions coverage job] --> Script
+    Script --> Vitest[Vitest Runner]
+    Vitest --> Config[vitest.config.ts]
+    Config --> Tests[Vitest test files]
+    Config --> Source[Coverage include scope]
+    Vitest --> Text[Terminal summary]
+    Vitest --> HTML[coverage/index.html]
+    Vitest --> LCOV[coverage/lcov.info]
+    Config --> Gate[Coverage thresholds]
+```
+
+**Architecture Integration**:
+
+- **Selected pattern**: Existing config extension.
+- **Domain boundaries**: Vitest coverage は単体・統合テストによるロジック測定、Playwright は E2E/visual regression。
+- **Existing patterns preserved**: `coverage/` artifact, v8 provider, CI continue-on-error.
+- **New components rationale**: report-only script を追加する場合のみ、日常測定の exit code を安定化できる。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Test Runner | Vitest 4.1.4 | Unit/integration test execution | lockfile resolved version |
+| Coverage Provider | @vitest/coverage-v8 4.1.4 | V8 coverage collection | `pnpm install --frozen-lockfile` で同期 |
+| Reports | text/html/lcov | Human and tool-readable output | `coverage/` ignored |
+| CI | GitHub Actions | Continuous observation | `coverage` job is non-blocking |
+
+## System Flows
+
+### Report-only Measurement Flow
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant PNPM as pnpm script
+    participant Vitest as Vitest
+    participant FS as coverage/
+
+    Dev->>PNPM: run report-only coverage
+    PNPM->>Vitest: vitest run --coverage with threshold override
+    Vitest->>Vitest: run 14 test files
+    Vitest->>FS: write html and lcov reports
+    Vitest-->>Dev: print summary and exit 0 when tests pass
+```
+
+### Quality Gate Flow
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer / CI
+    participant PNPM as pnpm script
+    participant Vitest as Vitest
+    participant Gate as Thresholds
+
+    Dev->>PNPM: pnpm test:coverage
+    PNPM->>Vitest: vitest run --coverage
+    Vitest->>Gate: compare measured coverage with config thresholds
+    alt thresholds satisfied
+        Vitest-->>Dev: exit 0
+    else thresholds violated
+        Vitest-->>Dev: print coverage errors and exit 1
+    end
+```
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | 測定対象の固定 | `vitest.config.ts` | coverage.include | Report-only, Quality gate |
+| 1.2 | 除外対象の固定 | `vitest.config.ts` | coverage.exclude | Report-only, Quality gate |
+| 1.3 | 依存同期手順 | `pnpm-lock.yaml`, README/task docs | `pnpm install --frozen-lockfile` | Report-only |
+| 1.4 | E2E除外 | `playwright.config.ts`, `vitest.config.ts` | separate test runners | Both |
+| 2.1 | ターミナル表示 | Vitest reporter | text reporter | Both |
+| 2.2 | HTML生成 | Vitest reporter | html reporter | Both |
+| 2.3 | LCOV生成 | Vitest reporter | lcov reporter | Both |
+| 2.4 | artifact除外 | `.gitignore` | `coverage/` | Both |
+| 3.1 | report-only exit 0 | package script or CLI override | threshold override | Report-only |
+| 3.2 | threshold check exit 1 | `vitest.config.ts` | coverage.thresholds | Quality gate |
+| 3.3 | threshold変更根拠 | spec docs | baseline table | Quality gate |
+| 3.4 | 現行scriptの意味 | README/spec docs | `pnpm test:coverage` | Quality gate |
+| 4.1 | CI実行 | `.github/workflows/ci.yml` | coverage job | Quality gate |
+| 4.2 | 初期非blocking | `.github/workflows/ci.yml` | continue-on-error | Quality gate |
+| 4.3 | 段階的gate化 | tasks.md | task plan | Quality gate |
+| 4.4 | CI実行順 | `.github/workflows/ci.yml` | job steps | Quality gate |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `vitest.config.ts` | Test config | coverage provider, scope, reporters, thresholds を定義する | 1, 2, 3 | Vitest, coverage-v8 | Config |
+| `package.json` scripts | Developer UX | 測定と閾値チェックの入口を提供する | 1, 3 | pnpm, Vitest CLI | Command |
+| `.github/workflows/ci.yml` | CI | coverage を継続的に実行する | 4 | GitHub Actions, pnpm | Workflow |
+| `coverage/` | Artifact | HTML/LCOV/text output の生成先 | 2 | Vitest reporters | Filesystem |
+
+### Command Contract
+
+| Command | Purpose | Expected Exit |
+|---------|---------|---------------|
+| `pnpm test:coverage:report` | report-only measurement | tests 通過時は 0 |
+| `pnpm test:coverage` | configured thresholds を含む quality gate | 80%未満の指標がある場合は 1 |
+| `pnpm test:coverage:check` | quality gate の明示名 | 80%未満の指標がある場合は 1 |
+
+追加した `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "test:coverage:report": "vitest run --coverage --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0 --coverage.thresholds.branches=0",
+    "test:coverage:check": "vitest run --coverage"
+  }
+}
+```
+
+## Verification
+
+### Quality Gate Command
+
+- **Command**: `pnpm test:coverage`
+- **Observed Result**:
+  - Test Files: 20 passed
+  - Tests: 205 passed
+  - Exit: 0
+  - Reason: all global coverage metrics are above 80%
+
+### Report-only Command
+
+- **Command**: `pnpm test:coverage:report`
+- **Observed Result**:
+  - Test Files: 20 passed
+  - Tests: 205 passed
+  - Exit: 0
+  - Reports: `coverage/index.html`, `coverage/lcov.info`
+
+### Current Coverage Baseline
+
+| Metric | Current | Configured Threshold |
+|--------|---------|----------------------|
+| Statements | 97.97% | 80% |
+| Branches | 89.71% | 80% |
+| Functions | 95.23% | 80% |
+| Lines | 98.90% | 80% |

--- a/.kiro/specs/20260505-test-coverage-measurement/requirements.md
+++ b/.kiro/specs/20260505-test-coverage-measurement/requirements.md
@@ -1,0 +1,70 @@
+# Requirements Document
+
+## Table of Contents
+
+| Section | What You'll Learn |
+|---------|-------------------|
+| [Introduction](#introduction) | カバレッジ測定の目的と今回の対象範囲を示す |
+| [Requirement 1: カバレッジ測定の再現性](#requirement-1-カバレッジ測定の再現性) | 開発者が同じ手順で測定結果を取得できる条件を定義する |
+| [Requirement 2: 測定結果の可視化](#requirement-2-測定結果の可視化) | ターミナル、HTML、LCOV の各レポート要件を定義する |
+| [Requirement 3: 閾値チェックとの責務分離](#requirement-3-閾値チェックとの責務分離) | report-only と quality gate の使い分けを定義する |
+| [Requirement 4: CIでの継続測定](#requirement-4-ciでの継続測定) | CI 上でカバレッジを継続的に観測する条件を定義する |
+
+## Introduction
+
+この spec は、Astro + Cloudflare Pages Functions 構成のブログサイトで、Vitest によるテストカバレッジを安定して測定・確認できる状態を作るための要件を定義する。
+
+既存構成には `pnpm test:coverage`、Vitest v8 coverage 設定、CI の `coverage` job が存在する。2026-05-05 時点では、初期ゲートとして全体 coverage 80%以上を採用する。今回の主目的は「測定結果を再現可能に取得すること」と「現実的な初期品質ゲートを通すこと」であり、日常測定用の report-only command と品質ゲート用の check command の責務を分ける。
+
+### Current Baseline
+
+| Metric | Current |
+|--------|---------|
+| Statements | 97.97% |
+| Branches | 89.71% |
+| Functions | 95.23% |
+| Lines | 98.90% |
+
+## Requirement 1: カバレッジ測定の再現性
+
+**Objective:** 開発者として、ローカル環境で同じコマンドを実行すれば同じ対象範囲のカバレッジを測定したい。変更前後の比較を安定して行えるようにするため。
+
+#### Acceptance Criteria
+
+1. When 開発者が依存関係を同期した状態で測定コマンドを実行する, the Vitest coverage shall `functions/**/*.ts`, `src/lib/**/*.ts`, `src/hooks/**/*.ts`, `src/components/knowledge/format.ts` を測定対象にする
+2. When 測定対象にテストファイルや生成物が含まれる, the Vitest coverage shall `**/*.test.ts`, `**/*.test.tsx`, `node_modules/**`, `dist/**`, `coverage/**` を測定対象から除外する
+3. If `node_modules` が lockfile と同期していない, then the developer workflow shall `pnpm install --frozen-lockfile` を先に実行する手順を示す
+4. The measurement workflow shall Playwright E2E/snapshot test を coverage の対象に含めない
+
+## Requirement 2: 測定結果の可視化
+
+**Objective:** 開発者として、カバレッジ結果をターミナルとブラウザで確認したい。全体傾向と未カバー行の両方を素早く確認できるようにするため。
+
+#### Acceptance Criteria
+
+1. When 測定コマンドを実行する, the Vitest coverage shall ターミナルに summary table を表示する
+2. When 測定コマンドが完了する, the Vitest coverage shall `coverage/index.html` を生成する
+3. When 測定コマンドが完了する, the Vitest coverage shall `coverage/lcov.info` を生成する
+4. The coverage artifacts shall Git 管理対象に含めない
+
+## Requirement 3: 閾値チェックとの責務分離
+
+**Objective:** 開発者として、測定だけをしたい場合と、閾値違反を検出したい場合を分けたい。日常的な観測が不要に失敗扱いにならないようにするため。
+
+#### Acceptance Criteria
+
+1. When 開発者が report-only 測定を実行する, the command shall テストが通過している限り coverage threshold によって exit 1 にならない
+2. When 開発者が quality gate 測定を実行する, the command shall configured thresholds を満たさない場合に exit 1 になる
+3. The configured thresholds shall statements, branches, functions, lines の全体値をそれぞれ 80% 以上に設定する
+4. The workflow shall 現行の `pnpm test:coverage` が threshold check として振る舞うことを明示する
+
+## Requirement 4: CIでの継続測定
+
+**Objective:** 開発者として、Pull Request や main push でカバレッジを継続的に観測したい。ローカルで見落としたカバレッジ低下を把握できるようにするため。
+
+#### Acceptance Criteria
+
+1. When CI が実行される, the workflow shall `coverage` job で Vitest coverage を実行する
+2. While 初期導入期間である, the coverage job shall `continue-on-error: true` により他ジョブの blocking gate にしない
+3. If coverage gate を引き上げる, then the workflow shall threshold を現在の baseline から段階的に上げる方針を持つ
+4. The CI workflow shall dependency install, test execution, coverage reporting の順で実行される

--- a/.kiro/specs/20260505-test-coverage-measurement/research.md
+++ b/.kiro/specs/20260505-test-coverage-measurement/research.md
@@ -1,0 +1,119 @@
+# Research: test-coverage-measurement
+
+## Table of Contents
+
+| Section | What You'll Learn |
+|---------|-------------------|
+| [Summary](#summary) | 現在のカバレッジ基盤と実測結果の要点を示す |
+| [Research Log](#research-log) | 調査した設定、コマンド、失敗理由を記録する |
+| [Design Decisions](#design-decisions) | 測定と閾値チェックを分ける判断を説明する |
+| [Risks & Mitigations](#risks--mitigations) | カバレッジ運用上のリスクと対策を整理する |
+
+## Summary
+
+- **Feature**: test-coverage-measurement
+- **Discovery Scope**: Existing coverage setup verification
+- **Key Findings**:
+  - `package.json` には `test:coverage` があり、`vitest.config.ts` には v8 coverage 設定がある。
+  - CI には `coverage` job があり、`continue-on-error: true` で初期運用の警告扱いになっている。
+  - 初期改善後の `pnpm test:coverage:check` は、全体80%閾値を満たして exit 0 になる。
+  - CLI で閾値を 0 に上書きすると、同じ測定対象で exit 0 のレポート専用実行ができる。
+
+## Research Log
+
+### Existing Test Stack
+
+- **Context**: カバレッジ測定の導入状況を確認するため。
+- **Sources Consulted**:
+  - `package.json`
+  - `vitest.config.ts`
+  - `.github/workflows/ci.yml`
+  - `README.md`
+- **Findings**:
+  - Unit/integration test runner は Vitest。
+  - E2E/snapshot は Playwright で、カバレッジ測定対象には含めていない。
+  - Coverage provider は `@vitest/coverage-v8`。
+  - Coverage reporters は `text`, `html`, `lcov`。
+- **Implications**:
+  - JS/TS のユニットテストカバレッジは既存基盤で測定できる。
+  - Playwright の画面テストは目的が異なるため、今回の coverage gate には含めない。
+
+### Coverage Target Scope
+
+- **Context**: 測定対象が広すぎると UI コンポーネント全体を無理に数値化し、メンテナンス性を落とすため。
+- **Sources Consulted**:
+  - `vitest.config.ts`
+  - `src/**/*.test.{ts,tsx}`
+  - `functions/**/*.test.ts`
+- **Findings**:
+  - Coverage include は `functions/**/*.ts`, `src/lib/**/*.ts`, `src/hooks/**/*.ts`, `src/components/knowledge/format.ts`。
+  - React コンポーネント全体ではなく、関数・hook・API proxy 周辺を主対象にしている。
+  - 未カバーの主な低下要因は `src/hooks/useImageLazyLoad.ts`, `src/hooks/useScrapboxData.ts`, `src/lib/queryClient.ts`。
+- **Implications**:
+  - 現在の対象範囲は「ロジック中心」の測定として妥当。
+  - 測定値を上げるなら hooks と query client 周辺から始めるのが効果的。
+
+### Measurement Result
+
+- **Command**: `pnpm test:coverage`
+- **Result**: Test Files 14 passed / Tests 189 passed / exit 1 due to thresholds.
+- **Coverage Summary**:
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Statements | 79.79% (158/198) | 97.97% (194/198) |
+| Branches | 73.83% (79/107) | 89.71% (96/107) |
+| Functions | 64.28% (27/42) | 95.23% (40/42) |
+| Lines | 80.21% (146/182) | 98.90% (180/182) |
+
+- **Thresholds**:
+
+| Metric | Threshold | Status |
+|--------|-----------|--------|
+| Statements | 80% | Pass |
+| Branches | 80% | Pass |
+| Functions | 80% | Pass |
+| Lines | 80% | Pass |
+
+### Report-only Execution
+
+- **Command**: `pnpm exec vitest run --coverage --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0 --coverage.thresholds.branches=0`
+- **Result**: Test Files 14 passed / Tests 189 passed / exit 0.
+- **Generated Artifacts**:
+  - `coverage/index.html`
+  - `coverage/lcov.info`
+  - `coverage/lcov-report/index.html`
+
+## Design Decisions
+
+### Decision: Keep Coverage Scope Focused on Logic
+
+- **Context**: Astro/React UI と Cloudflare Functions が混在する構成で、すべてを同じ coverage threshold に含めると測定値がノイズ化しやすい。
+- **Alternatives Considered**:
+  1. Include all `src/**/*.ts(x)` files.
+  2. Keep current logic-oriented include list.
+- **Selected Approach**: 現在の `include` 方針を維持する。
+- **Rationale**: 表示確認は Playwright snapshot が担い、Vitest coverage はロジックの回帰検出に集中させる。
+- **Trade-offs**: UI コンポーネントの未測定領域は数値に出にくい。
+- **Follow-up**: UI の重要ロジックは hook や pure function に分離して測定対象に入れる。
+
+### Decision: Separate Report-only Measurement from Threshold Check
+
+- **Context**: `pnpm test:coverage` は測定結果を出すが、現行閾値が高いため常に失敗しやすい。
+- **Alternatives Considered**:
+  1. 閾値を現在値まで下げる。
+  2. `test:coverage` の閾値を外す。
+  3. 測定専用コマンドと閾値チェックコマンドを分ける。
+- **Selected Approach**: 測定専用と閾値チェックを分ける。
+- **Rationale**: 日常的な可視化と品質ゲートは別のユースケースであり、同じ exit code にすると運用意図が曖昧になる。
+- **Trade-offs**: npm script が1つ増える。
+- **Follow-up**: `test:coverage:report` を npm script として追加済み。品質ゲート用途は `test:coverage:check` を使う。
+
+## Risks & Mitigations
+
+- **Risk**: 100% 閾値が常に失敗し、開発者が coverage job を無視する。
+  - **Mitigation**: report-only command を用意し、閾値チェックは段階的に現実的な値へ調整する。
+- **Risk**: Coverage を上げるためだけの低価値テストが増える。
+  - **Mitigation**: hooks/API proxy の分岐やエラー処理など、実際の回帰リスクが高い箇所を優先する。
+- **Risk**: `node_modules` が lockfile と同期していないと coverage provider が見つからない。
+  - **Mitigation**: 測定前に `pnpm install --frozen-lockfile` を実行する。

--- a/.kiro/specs/20260505-test-coverage-measurement/spec.json
+++ b/.kiro/specs/20260505-test-coverage-measurement/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "test-coverage-measurement",
+  "created_at": "2026-05-05T15:56:12+09:00",
+  "updated_at": "2026-05-05T22:58:00+09:00",
+  "language": "ja",
+  "phase": "implementation",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/20260505-test-coverage-measurement/tasks.md
+++ b/.kiro/specs/20260505-test-coverage-measurement/tasks.md
@@ -1,0 +1,78 @@
+# Implementation Plan
+
+## Overview
+
+| # | Task | Requirements | Parallel |
+|---|------|--------------|----------|
+| 1 | 現在の coverage baseline を記録する | 1.1, 2.1, 2.2, 2.3 | - |
+| 2 | report-only 測定コマンドを npm script 化する | 3.1, 3.4 | (P) |
+| 3 | quality gate 用コマンド名を明示する | 3.2, 3.4 | (P) |
+| 4 | README に測定と閾値チェックの違いを追記する | 1.3, 2.4, 3.1, 3.2 | - |
+| 5 | CI coverage job の運用方針を明文化する | 4.1, 4.2, 4.3, 4.4 | - |
+| 6 | カバレッジ改善対象を優先順位付けする | 3.3 | (P) |
+| 7 | hook/libテストを追加して全体80%以上に引き上げる | 3.3 | - |
+| 8 | coverage threshold を80%初期ゲートに調整する | 3.2, 3.3, 4.3 | - |
+| 9 | component配線テストを追加する | 3.3 | - |
+| 10 | クロスレビュー指摘を反映する | 2.4, 3.3 | - |
+
+- [x] 1. 現在の coverage baseline を記録する
+  - `pnpm test:coverage` を実行し、14 test files / 189 tests が通過することを確認する
+  - threshold 違反により exit 1 になることを確認する
+  - `coverage/index.html` と `coverage/lcov.info` が生成されることを確認する
+  - 初期値: statements 79.79%, branches 73.83%, functions 64.28%, lines 80.21%
+  - _Requirements: 1.1, 2.1, 2.2, 2.3_
+
+- [x] 2. report-only 測定コマンドを npm script 化する (P)
+  - `package.json` に `test:coverage:report` を追加する
+  - CLI override で coverage thresholds を 0 にし、テスト通過時は exit 0 にする
+  - 追加後に `pnpm test:coverage:report` を実行し、exit 0 と HTML/LCOV 生成を確認する
+  - _Requirements: 3.1, 3.4_
+
+- [x] 3. quality gate 用コマンド名を明示する (P)
+  - `package.json` に `test:coverage:check` を追加し、`vitest run --coverage` を割り当てる
+  - 既存の `test:coverage` を残す場合は threshold check として扱う
+  - `pnpm test:coverage:check` が現行 threshold 違反で exit 1 になることを確認する
+  - _Requirements: 3.2, 3.4_
+
+- [x] 4. README に測定と閾値チェックの違いを追記する
+  - `pnpm test:coverage:report` は日常的な測定・HTML確認用であることを記載する
+  - `pnpm test:coverage` / `pnpm test:coverage:check` は threshold check であることを記載する
+  - `coverage/` は生成物で Git 管理しないことを記載する
+  - _Requirements: 1.3, 2.4, 3.1, 3.2_
+
+- [x] 5. CI coverage job の運用方針を明文化する
+  - 現行の `continue-on-error: true` を初期観測フェーズとして説明する
+  - 必須 gate 化する条件を、現在 baseline から段階的に上げる方針として記載する
+  - CI で report-only にするか quality gate を継続するかは別判断として残す
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [x] 6. カバレッジ改善対象を優先順位付けする (P)
+  - First priority: `src/hooks/useImageLazyLoad.ts` と `src/hooks/useScrapboxData.ts` の基本分岐をテストする
+  - Second priority: `src/lib/queryClient.ts` の初期化挙動をテストする
+  - Third priority: `functions/_lib/knowledge-proxy.ts` の未カバー分岐を補う
+  - 低価値な snapshot 的テストではなく、エラー処理・分岐・副作用境界を優先する
+  - _Requirements: 3.3_
+
+- [x] 7. hook/libテストを追加して全体80%以上に引き上げる
+  - `src/hooks/useImageLazyLoad.test.tsx` を追加し、IntersectionObserver連携、loadイベント、cleanupを検証する
+  - `src/hooks/useScrapboxData.test.tsx` を追加し、fetch成功、limit適用、disabled query、API errorを検証する
+  - `src/hooks/useKnowledgeDataHook.test.tsx` を追加し、knowledge proxy成功、API error、disabled queryを検証する
+  - `src/lib/queryClient.test.ts` を追加し、React Query の既定値を検証する
+  - hook/libテスト追加後の値: statements 97.47%, branches 88.78%, functions 95.23%, lines 98.90%
+  - _Requirements: 3.3_
+
+- [x] 8. coverage threshold を80%初期ゲートに調整する
+  - `vitest.config.ts` の statements, branches, functions, lines threshold を80%に設定する
+  - `pnpm test:coverage:check` がテスト通過かつ全体80%以上で成功することを確認する
+  - _Requirements: 3.2, 3.3, 4.3_
+
+- [x] 9. component配線テストを追加する
+  - `src/components/scrapbox/ScrapboxCard.test.tsx` を追加し、`useImageLazyLoad` と `ScrapboxCard` の `img src` 遅延配線を検証する
+  - `src/components/scrapbox/ScrapboxCardList.test.tsx` を追加し、公開コンポーネント経由で `QueryProvider -> useScrapboxData -> fetch -> UI` が通ることを検証する
+  - 配線テスト追加後の現在値: statements 97.97%, branches 89.71%, functions 95.23%, lines 98.90%
+  - _Requirements: 3.3_
+
+- [x] 10. クロスレビュー指摘を反映する
+  - Codex CLI review の P1 指摘に基づき、`.claude/worktrees/` を `.gitignore` に追加して巨大な生成worktreeの誤コミットを防止する
+  - Claude Code ultrareview は起動したが、5分timeoutで詳細結果を取得できなかった
+  - _Requirements: 2.4, 3.3_

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ pnpm install
 | `pnpm format`        | フォーマット             |
 | `pnpm typecheck`     | TypeScript 型チェック  |
 | `pnpm test:run`      | Vitest 実行        |
-| `pnpm test:coverage` | カバレッジ計測          |
+| `pnpm test:coverage:report` | カバレッジ計測（閾値チェックなし） |
+| `pnpm test:coverage` | カバレッジ閾値チェック      |
+| `pnpm test:coverage:check` | カバレッジ閾値チェック（明示名） |
 | `pnpm test:e2e`      | Playwright E2E テスト |
 
 ### Cloudflare Pages Functions のローカル実行

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:coverage:report": "vitest run --coverage --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0 --coverage.thresholds.branches=0",
+    "test:coverage:check": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:update-snapshots": "playwright test --update-snapshots"

--- a/src/components/scrapbox/ScrapboxCard.test.tsx
+++ b/src/components/scrapbox/ScrapboxCard.test.tsx
@@ -1,0 +1,82 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrapboxPageData } from "@/types/scrapbox";
+import { ScrapboxCard } from "./ScrapboxCard";
+
+class MockIntersectionObserver {
+  private callback: IntersectionObserverCallback;
+  static instances: MockIntersectionObserver[] = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe() {}
+
+  disconnect() {}
+
+  trigger(entry: Partial<IntersectionObserverEntry>) {
+    this.callback(
+      [
+        {
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRatio: 0,
+          intersectionRect: {} as DOMRectReadOnly,
+          isIntersecting: false,
+          rootBounds: null,
+          target: document.createElement("img"),
+          time: Date.now(),
+          ...entry,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+function page(overrides?: Partial<ScrapboxPageData>): ScrapboxPageData {
+  return {
+    id: "page-1",
+    title: "Scrapbox note",
+    imageUrl: "https://example.com/image.png",
+    description: "A linked note",
+    updatedAt: "2026-05-05T00:00:00Z",
+    url: "https://scrapbox.io/example/page-1",
+    ...overrides,
+  };
+}
+
+describe("ScrapboxCard", () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("画像がビューポートに入るまでsrcを遅延し、交差後に画像URLを設定する", () => {
+    render(<ScrapboxCard page={page()} />);
+
+    const image = screen.getByAltText("Scrapbox note");
+    expect(image).not.toHaveAttribute("src");
+
+    act(() => {
+      MockIntersectionObserver.instances[0].trigger({
+        isIntersecting: true,
+        target: image,
+      });
+    });
+
+    expect(image).toHaveAttribute("src", "https://example.com/image.png");
+  });
+
+  it("画像URLがない場合はプレースホルダーを表示する", () => {
+    render(<ScrapboxCard page={page({ imageUrl: null })} />);
+
+    expect(screen.getByTestId("image-placeholder")).toBeInTheDocument();
+    expect(screen.queryByAltText("Scrapbox note")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/scrapbox/ScrapboxCardList.test.tsx
+++ b/src/components/scrapbox/ScrapboxCardList.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queryClient } from "@/lib/queryClient";
+import type { ScrapboxPageData } from "@/types/scrapbox";
+import { ScrapboxCardList } from "./ScrapboxCardList";
+
+function page(id: string, overrides?: Partial<ScrapboxPageData>): ScrapboxPageData {
+  return {
+    id,
+    title: id,
+    imageUrl: null,
+    description: "[Scrapbox] https://example.com note",
+    updatedAt: "2026-05-05T00:00:00Z",
+    url: `https://scrapbox.io/example/${id}`,
+    ...overrides,
+  };
+}
+
+describe("ScrapboxCardList", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("QueryProvider経由でproxyから取得したページを一覧表示する", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify([page("one"), page("two")]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    render(<ScrapboxCardList project="project name" limit={1} />);
+
+    await waitFor(() => expect(screen.getByText("one")).toBeInTheDocument());
+
+    expect(fetch).toHaveBeenCalledWith("/api/pages/project%20name?limit=100");
+    expect(screen.queryByText("two")).not.toBeInTheDocument();
+    expect(screen.getByText("Scrapbox note")).toBeInTheDocument();
+  });
+
+  it("project未指定ならfetchせずエラー表示する", () => {
+    render(<ScrapboxCardList project="" />);
+
+    expect(screen.getByText("プロジェクト名を指定してください")).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useImageLazyLoad.test.tsx
+++ b/src/hooks/useImageLazyLoad.test.tsx
@@ -1,0 +1,113 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useImageLazyLoad } from "./useImageLazyLoad";
+
+class MockIntersectionObserver {
+  private callback: IntersectionObserverCallback;
+  private observedElements = new Set<Element>();
+  readonly options?: IntersectionObserverInit;
+  static instances: MockIntersectionObserver[] = [];
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.observedElements.add(element);
+  }
+
+  disconnect() {
+    this.observedElements.clear();
+  }
+
+  trigger(entry: Partial<IntersectionObserverEntry>) {
+    const target = entry.target ?? document.createElement("img");
+    this.callback(
+      [
+        {
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRatio: 0,
+          intersectionRect: {} as DOMRectReadOnly,
+          isIntersecting: false,
+          rootBounds: null,
+          target,
+          time: Date.now(),
+          ...entry,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+function LazyImageProbe(props: { rootMargin?: string; threshold?: number }) {
+  const { ref, isInView, isLoaded, onLoad } = useImageLazyLoad(props);
+
+  return (
+    <>
+      <img alt="lazy target" data-testid="target" onLoad={onLoad} ref={ref} />
+      <output aria-label="in-view">{String(isInView)}</output>
+      <output aria-label="loaded">{String(isLoaded)}</output>
+    </>
+  );
+}
+
+describe("useImageLazyLoad", () => {
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("デフォルト設定で画像を監視し、交差したらin-viewになる", () => {
+    render(<LazyImageProbe />);
+
+    const observer = MockIntersectionObserver.instances[0];
+    expect(observer.options).toMatchObject({
+      rootMargin: "200px",
+      threshold: 0.1,
+    });
+
+    act(() => {
+      observer.trigger({
+        isIntersecting: true,
+        target: screen.getByTestId("target"),
+      });
+    });
+
+    expect(screen.getByLabelText("in-view")).toHaveTextContent("true");
+  });
+
+  it("カスタム設定をIntersectionObserverに渡す", () => {
+    render(<LazyImageProbe rootMargin="50px" threshold={0.5} />);
+
+    expect(MockIntersectionObserver.instances[0].options).toMatchObject({
+      rootMargin: "50px",
+      threshold: 0.5,
+    });
+  });
+
+  it("画像のloadイベントでloadedになる", () => {
+    render(<LazyImageProbe />);
+
+    act(() => {
+      screen.getByTestId("target").dispatchEvent(new Event("load", { bubbles: true }));
+    });
+
+    expect(screen.getByLabelText("loaded")).toHaveTextContent("true");
+  });
+
+  it("アンマウント時にobserverを切断する", () => {
+    const { unmount } = render(<LazyImageProbe />);
+    const disconnectSpy = vi.spyOn(MockIntersectionObserver.instances[0], "disconnect");
+
+    unmount();
+
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useKnowledgeDataHook.test.tsx
+++ b/src/hooks/useKnowledgeDataHook.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { KnowledgePageData, KnowledgeProxyResponse } from "@/types/knowledge";
+import { useKnowledgeData } from "./useKnowledgeData";
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function page(id: string, hashtags: string[]): KnowledgePageData {
+  return {
+    id,
+    title: id,
+    hashtags,
+    updatedAt: "2026-05-05T00:00:00Z",
+    linked: 1,
+    linesCount: 10,
+    views: 0,
+  };
+}
+
+function response(pages: KnowledgePageData[]): KnowledgeProxyResponse {
+  return {
+    pages,
+    count: pages.length,
+    projectName: "project",
+  };
+}
+
+describe("useKnowledgeData", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("project名をエンコードしてknowledge proxyからページとタグ集計を返す", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(response([page("one", ["A"]), page("two", ["A", "B"])])), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { result } = renderHook(() => useKnowledgeData("project name"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.totalPages).toBe(2));
+
+    expect(fetch).toHaveBeenCalledWith("/api/knowledge/project%20name");
+    expect(result.current.pages.map((item) => item.id)).toEqual(["one", "two"]);
+    expect(result.current.tags.map((tag) => tag.name)).toEqual(["A", "B"]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("proxyが失敗したらerrorを返す", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response("error", { status: 503 }));
+
+    const { result } = renderHook(() => useKnowledgeData("project"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toEqual(new Error("API error: 503")));
+
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.tags).toEqual([]);
+    expect(result.current.totalPages).toBe(0);
+  });
+
+  it("projectが空ならfetchせず空の結果を返す", () => {
+    const { result } = renderHook(() => useKnowledgeData(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.tags).toEqual([]);
+    expect(result.current.totalPages).toBe(0);
+  });
+});

--- a/src/hooks/useScrapboxData.test.tsx
+++ b/src/hooks/useScrapboxData.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrapboxPageData } from "@/types/scrapbox";
+import { useScrapboxData } from "./useScrapboxData";
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+function page(id: string): ScrapboxPageData {
+  return {
+    id,
+    title: id,
+    imageUrl: null,
+    description: "",
+    updatedAt: "2026-05-05T00:00:00Z",
+    url: `https://scrapbox.io/example/${id}`,
+  };
+}
+
+describe("useScrapboxData", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("project名をエンコードしてproxyからページを取得する", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify([page("one"), page("two")]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { result } = renderHook(() => useScrapboxData("project name"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetch).toHaveBeenCalledWith("/api/pages/project%20name?limit=100");
+    expect(result.current.data?.map((item) => item.id)).toEqual(["one", "two"]);
+  });
+
+  it("limit指定時は取得結果を先頭から切り出す", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify([page("one"), page("two"), page("three")]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { result } = renderHook(() => useScrapboxData("project", { limit: 2 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.map((item) => item.id)).toEqual(["one", "two"]);
+  });
+
+  it("projectが空ならfetchを実行しない", () => {
+    const { result } = renderHook(() => useScrapboxData(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("proxyが失敗したらエラーを返す", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response("error", { status: 500 }));
+
+    const { result } = renderHook(() => useScrapboxData("project"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toEqual(new Error("API error: 500"));
+  });
+});

--- a/src/lib/queryClient.test.ts
+++ b/src/lib/queryClient.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { queryClient } from "./queryClient";
+
+describe("queryClient", () => {
+  it("クライアント側クエリの既定値を設定する", () => {
+    const defaultOptions = queryClient.getDefaultOptions();
+
+    expect(defaultOptions.queries).toMatchObject({
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,9 +26,9 @@ export default getViteConfig({
         "dist/**",
       ],
       thresholds: {
-        lines: 100,
-        functions: 100,
-        statements: 100,
+        lines: 80,
+        functions: 80,
+        statements: 80,
         branches: 80,
       },
     },


### PR DESCRIPTION
## 概要

テストカバレッジの計測基盤を整備し、品質ゲートを段階的に運用できる構成にした。
Kiro spec: `.kiro/specs/20260505-test-coverage-measurement/`

## 変更内容

### テスト追加（カバレッジ引き上げ）
- `src/hooks/useImageLazyLoad.test.tsx` — IntersectionObserver連携、loadイベント、cleanup
- `src/hooks/useScrapboxData.test.tsx` — fetch成功、limit適用、disabled query、APIエラー
- `src/hooks/useKnowledgeDataHook.test.tsx` — knowledge proxy成功、APIエラー、disabled query
- `src/lib/queryClient.test.ts` — React Query 既定値
- `src/components/scrapbox/ScrapboxCard.test.tsx` — `useImageLazyLoad` の img src 遅延配線
- `src/components/scrapbox/ScrapboxCardList.test.tsx` — `QueryProvider → useScrapboxData → fetch → UI` 配線

### coverage 設定
- `vitest.config.ts`: threshold を 100% → 80%（branches は既存80%維持）の初期ゲートに調整
- `package.json`: `test:coverage:report`（閾値チェックなし）と `test:coverage:check`（明示ゲート）を追加
- `.github/workflows/ci.yml`: coverage job を `test:coverage:check` に変更

### ドキュメント
- `README.md`: 測定コマンドと閾値チェックコマンドの違いを追記
- `.gitignore`: `.claude/worktrees/` を追加（生成worktreeの誤コミット防止）

## カバレッジ結果

| 項目 | 値 |
|------|-----|
| Statements | 97.97% |
| Branches | 89.71% |
| Functions | 95.23% |
| Lines | 98.9% |

## 検証

- `pnpm lint` ✅
- `pnpm test:coverage:check` ✅ (20 files / 205 tests pass, 全項目80%超)
- `pnpm build` ✅