### PR TITLE
UI: Rename Archive label to Posts

### DIFF
--- a/content/archives.md
+++ b/content/archives.md
@@ -1,6 +1,6 @@
 ---
-title: "Archive"
+title: "Posts"
 layout: "archives"
 url: "/archives"
-summary: "archives"
+summary: "posts"
 ---

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,10 @@
-{"pnpm":{"executionEnv":{"nodeVersion":""},"onlyBuiltDependencies":["esbuild","sharp"]}}
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+pnpm:
+  executionEnv:
+    nodeVersion: ""
+  onlyBuiltDependencies:
+    - esbuild
+    - sharp


### PR DESCRIPTION
## Summary
- Rename the remaining user-facing Archive metadata to Posts.
- Keep the existing `/archives` URL and `archives` layout unchanged because the issue only requests label changes.
- Add explicit pnpm build-script approvals required for `pnpm lint && pnpm test:run && pnpm build` to run cleanly in this workspace.

Closes #32

## Verification
- `pnpm lint && pnpm test:run && pnpm build`
