### PR TITLE
[codex] 記事ページのOGPメタタグを最適化

### DIFF
--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -5,10 +5,33 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  ogType?: "website" | "article";
+  articlePublishedTime?: Date | string;
+  articleModifiedTime?: Date | string;
+  articleTags?: string[];
 }
 
-const { title, description = "KJR020の技術ブログ", image = "/og-image.png" } = Astro.props;
+const {
+  title,
+  description = "KJR020の技術ブログ",
+  image = "/og-image.png",
+  ogType = "website",
+  articlePublishedTime,
+  articleModifiedTime,
+  articleTags = [],
+} = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+function toMetaDateTime(value: Date | string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+const publishedTime = toMetaDateTime(articlePublishedTime);
+const modifiedTime = toMetaDateTime(articleModifiedTime);
 ---
 
 <ThemeInit />
@@ -30,11 +53,15 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
 <meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={new URL(image, Astro.url)} />
+<meta property="og:locale" content="ja_JP" />
+{publishedTime && <meta property="article:published_time" content={publishedTime} />}
+{modifiedTime && <meta property="article:modified_time" content={modifiedTime} />}
+{articleTags.map((tag) => <meta property="article:tag" content={tag} />)}
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -14,21 +14,37 @@ function buildSite() {
   });
 }
 
+function readHtmlFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return readHtmlFiles(fullPath);
+    }
+
+    return entry.isFile() && entry.name === "index.html" ? [readFileSync(fullPath, "utf8")] : [];
+  });
+}
+
 describe("BaseHead OGP meta tags", () => {
   beforeAll(() => {
     buildSite();
   }, 60_000);
 
   it("renders article OGP meta tags on post pages", () => {
-    const postHtml = readFileSync(
-      join(distDir, "posts", "vitest", "vitestについて", "index.html"),
-      "utf8",
+    const postHtml = readHtmlFiles(join(distDir, "posts")).find(
+      (html) =>
+        html.includes("<title>Cookieとは - KJR020&#39;s Blog</title>") &&
+        html.includes('<meta property="article:tag" content="Cookie">'),
     );
 
+    expect(postHtml).toBeDefined();
     expect(postHtml).toContain('<meta property="og:type" content="article">');
     expect(postHtml).toContain('<meta property="og:locale" content="ja_JP">');
     expect(postHtml).toContain('<meta property="article:published_time"');
-    expect(postHtml).toContain('<meta property="article:tag" content="Vitest">');
+    expect(postHtml).toContain('<meta property="article:tag" content="Cookie">');
+    expect(postHtml).toContain('<meta property="article:tag" content="Web">');
+    expect(postHtml).toContain('<meta property="article:tag" content="HTTP">');
     expect(postHtml).not.toContain('<meta property="article:modified_time"');
   });
 

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const distDir = join(process.cwd(), "dist");
+const astroBin = join(process.cwd(), "node_modules", ".bin", "astro");
+
+function buildSite() {
+  execFileSync(astroBin, ["build"], {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  });
+}
+
+describe("BaseHead OGP meta tags", () => {
+  beforeAll(() => {
+    buildSite();
+  }, 60_000);
+
+  it("renders article OGP meta tags on post pages", () => {
+    const postHtml = readFileSync(
+      join(distDir, "posts", "vitest", "vitestについて", "index.html"),
+      "utf8",
+    );
+
+    expect(postHtml).toContain('<meta property="og:type" content="article">');
+    expect(postHtml).toContain('<meta property="og:locale" content="ja_JP">');
+    expect(postHtml).toContain('<meta property="article:published_time"');
+    expect(postHtml).toContain('<meta property="article:tag" content="Vitest">');
+    expect(postHtml).not.toContain('<meta property="article:modified_time"');
+  });
+
+  it("keeps website OGP type on non-post pages", () => {
+    const indexHtml = readFileSync(join(distDir, "index.html"), "utf8");
+
+    expect(indexHtml).toContain('<meta property="og:type" content="website">');
+    expect(indexHtml).toContain('<meta property="og:locale" content="ja_JP">');
+    expect(indexHtml).not.toContain('<meta property="article:published_time"');
+    expect(indexHtml).not.toContain('<meta property="article:tag"');
+  });
+});

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,15 +10,36 @@ interface Props {
   description?: string;
   image?: string;
   hideKuri?: boolean;
+  ogType?: "website" | "article";
+  articlePublishedTime?: Date | string;
+  articleModifiedTime?: Date | string;
+  articleTags?: string[];
 }
 
-const { title, description, image, hideKuri = false } = Astro.props;
+const {
+  title,
+  description,
+  image,
+  hideKuri = false,
+  ogType,
+  articlePublishedTime,
+  articleModifiedTime,
+  articleTags,
+} = Astro.props;
 ---
 
 <!doctype html>
 <html lang="ja" class="scroll-smooth">
   <head>
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      ogType={ogType}
+      articlePublishedTime={articlePublishedTime}
+      articleModifiedTime={articleModifiedTime}
+      articleTags={articleTags}
+    />
   </head>
   <body class="flex min-h-screen flex-col bg-background text-foreground antialiased overflow-x-hidden">
     <Header />

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -36,6 +36,9 @@ const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID;
 <BaseLayout
   title={`${post.data.title} - KJR020's Blog`}
   description={post.data.description}
+  ogType="article"
+  articlePublishedTime={post.data.date}
+  articleTags={post.data.tags}
 >
   <div class="post-page container mx-auto px-4 py-phi-2xl max-w-6xl">
     <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_250px] lg:gap-phi-2xl">


### PR DESCRIPTION
## 概要
- BaseHead/BaseLayout にOG種別と記事メタ情報用のpropsを追加しました
- 記事ページでは `og:type=article` と `article:published_time` / `article:tag` / `og:locale=ja_JP` を出力します
- 記事以外のページでは既存どおり `og:type=website` を維持します
- build後HTMLを確認するfocused testを追加しました

Closes #51

## 検証
- `./node_modules/.bin/vitest run src/layouts/BaseHead.ogp.test.ts`
- `./node_modules/.bin/biome check src/`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/astro build`
- `astro preview` + Playwrightで記事ページ/トップページを画面確認
  - 記事ページ: `og:type=article`, `og:locale=ja_JP`, `article:published_time`, `article:tag=Vitest` を確認
  - トップページ: `og:type=website`, `og:locale=ja_JP`, article系metaなしを確認
  - スクリーンショット上、記事ページとトップページに大きな表示崩れなし

## 補足
- `pnpm lint` / `pnpm test:run` / `pnpm build` は、スクリプト実行前にpnpmのsupply-chain policy checkで停止しました。既存lockfileのtarball URLが `registry.npmjs.org`、現在のregistry metadataが `npm.flatt.tech` で不一致になる `ERR_PNPM_TARBALL_URL_MISMATCH` が原因です。
- 同等の実体コマンドではlint/test/build相当の検証は通過しています。
- 画面確認時に `Giscus configuration is incomplete` warning と一部404 resourceを確認しましたが、今回変更したOGP出力とは無関係です。