### PR TITLE
Add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kjr020.dev/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Add `public/robots.txt` to allow all crawlers.
- Reference the current sitemap URL: `https://kjr020.dev/sitemap-index.xml`.
- Issue #46 mentioned `kjr020.github.io`, but the current Astro `site` config is `https://kjr020.dev`, so robots.txt follows the migrated production domain.

Closes #46

## Verification
- `/opt/homebrew/bin/pnpm lint`
- `/opt/homebrew/bin/pnpm test:run`
- `/opt/homebrew/bin/pnpm build`
- Confirmed `dist/robots.txt` contains the expected Sitemap URL.
- Confirmed `dist/sitemap-index.xml` is generated.