### PR TITLE
[codex] ディレクトリ構成ドキュメントを現状に合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ graph TB
 src/
 ├── components/          # UI コンポーネント (Astro / React)
 │   └── knowledge/       #   Knowledge Graph 関連
-├── content/posts/       # ブログ記事 (Markdown)
 ├── hooks/               # React Hooks
 ├── layouts/             # ページレイアウト
 ├── lib/                 # ユーティリティ
@@ -87,9 +86,18 @@ functions/
     ├── pages/           # Scrapbox ページ一覧 Proxy
     └── knowledge/       # Knowledge Graph 用全ページ取得 Proxy
 
+content/
+└── posts/               # ブログ記事 (Markdown)
+
+e2e/
+├── helpers/             # Playwright E2E / visual regression helper
+└── *.spec.ts            # E2E テスト
+
 docs/
+├── index.html           # GitHub Pages 旧URLから kjr020.dev へのリダイレクト
+├── 404.html             # GitHub Pages 旧パスから kjr020.dev 同一パスへのリダイレクト
 ├── architecture/        # 設計ドキュメント
-└── security/            # セキュリティ検証チェックリスト
+└── security/            # セキュリティ検証・依存管理チェックリスト
 ```
 
 <details>
@@ -146,6 +154,8 @@ SCRAPBOX_SID=your-connect-sid-value
 
 Cloudflare Pages に自動デプロイ。`main` ブランチへの push で GitHub Actions → Cloudflare Pages にビルド・デプロイされる。
 
+`kjr020.github.io` から `kjr020.dev` への旧URL互換リダイレクトは、GitHub Pages の `/docs` 配信で維持している。`docs/index.html` と `docs/404.html` は生成物ではなく、このリダイレクト用途の手動管理ファイル。
+
 ## ライセンス
 
-記事コンテンツ (`src/content/`) の著作権は著者に帰属します。ソースコードは自由に参照してください。
+記事コンテンツ (`content/posts/`) の著作権は著者に帰属します。ソースコードは自由に参照してください。

--- a/docs/architecture/test_architecture.md
+++ b/docs/architecture/test_architecture.md
@@ -10,10 +10,11 @@
 - CI/CD パイプラインでの自動テスト実行
 
 ### テストフレームワーク
-- **Vitest**: Vite ネイティブのテストランナー（Astro 公式推奨）
+- **Vitest**: Unit / Component テスト用の Vite ネイティブテストランナー
+- **Playwright**: E2E / Visual regression テスト用のブラウザテストランナー
 
 ### ファイル配置
-テストファイルはソースファイルと同じディレクトリに配置する（コロケーション）。
+Unit / Component テストファイルは、ソースファイルと同じディレクトリに配置する（コロケーション）。
 
 ```
 src/
@@ -24,6 +25,17 @@ src/
     └── ui/
         ├── button.tsx
         └── button.test.tsx
+```
+
+E2E テストは `playwright.config.ts` の `testDir` に合わせて配置する。現状は `e2e/` を使用している。
+
+```
+e2e/
+├── header.spec.ts
+├── snapshot.spec.ts
+├── snapshot.css
+└── helpers/
+    └── snapshot.ts
 ```
 
 ## テスト対象の評価基準
@@ -50,17 +62,19 @@ src/
 
 ### Unit Tests
 - 純粋関数、ユーティリティ関数
-- テスト環境: `node`
+- テスト環境: `jsdom`（現行設定）
 - 依存関係: なし
 
-### Component Tests（将来）
+### Component Tests
 - React コンポーネントのロジック
-- テスト環境: `jsdom` または `happy-dom`
+- テスト環境: `jsdom`
 - 依存関係: `@testing-library/react`
 
-### E2E Tests（スコープ外）
-- Playwright を使用（別途導入済み）
-- 本ドキュメントのスコープ外
+### E2E Tests
+- Playwright を使用
+- 配置: `e2e/**/*.spec.ts`
+- `pnpm test:e2e` で実行
+- スナップショット安定化CSSは `e2e/snapshot.css`
 
 ## 設定ファイル
 
@@ -72,9 +86,25 @@ import { getViteConfig } from "astro/config";
 
 export default getViteConfig({
   test: {
-    environment: "node",
-    include: ["src/**/*.test.{ts,tsx}"],
+    environment: "jsdom",
     globals: true,
+    include: ["src/**/*.test.{ts,tsx}", "functions/**/*.test.ts"],
+    setupFiles: ["./src/test/setup.ts"],
+  },
+});
+```
+
+### playwright.config.ts
+
+```typescript
+import { defineConfig } from "playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  expect: {
+    toHaveScreenshot: {
+      stylePath: "./e2e/snapshot.css",
+    },
   },
 });
 ```
@@ -86,7 +116,7 @@ export default getViteConfig({
   "scripts": {
     "test": "vitest",
     "test:run": "vitest run",
-    "test:watch": "vitest watch"
+    "test:e2e": "playwright test"
   }
 }
 ```
@@ -101,9 +131,14 @@ export default getViteConfig({
 - `--passWithNoTests`: テストファイルがない場合もエラーにしない
 - `test:run`: ウォッチモードではなく単発実行
 
+```yaml
+- name: Run E2E tests
+  run: pnpm test:e2e
+```
+
 ## カバレッジ計測
 
-現時点ではカバレッジ計測は行わない。必要に応じて以下を追加:
+Vitest のカバレッジ計測を使用する。測定対象は `vitest.config.ts` の `coverage.include` で明示する。
 
 ```typescript
 // vitest.config.ts
@@ -111,8 +146,8 @@ export default getViteConfig({
   test: {
     coverage: {
       provider: "v8",
-      reporter: ["text", "html"],
-      include: ["src/**/*.ts"],
+      reporter: ["text", "html", "lcov"],
+      include: ["functions/**/*.ts", "src/lib/**/*.ts", "src/hooks/**/*.ts"],
     },
   },
 });


### PR DESCRIPTION
## Summary

- README のプロジェクト構成を現行の `content/posts/`, `e2e/`, `docs/` 用途に合わせて更新
- `docs/index.html` / `docs/404.html` が GitHub Pages 旧URL互換リダイレクト用の手動管理ファイルであることを明記
- テスト設計ドキュメントを現行の Vitest / Playwright 構成に合わせて更新

## Scope

Issue #69 のうち、調査済みのドキュメント不一致を直す小さなPRです。`e2e/` の移動や `content/posts` と `src/content/posts` の二重管理解消はこのPRでは実施していません。

Refs #69

## Verification

Node 22 (`mise exec node@22`) で確認済み。

- `pnpm lint`
- `pnpm test:run` (20 files / 205 tests)
- `pnpm build`

`pnpm test:run` / `pnpm build` では `punycode` の deprecation warning が出ますが、コマンドは成功しています。