### PR TITLE
[codex] 検索エンジン向け JSON-LD 構造化データを追加

### DIFF
--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -1,5 +1,6 @@
 ---
 import ThemeInit from "@/components/ThemeInit.astro";
+import { buildPageStructuredData, serializeJsonLd } from "@/lib/structuredData";
 
 interface Props {
   title: string;
@@ -9,6 +10,7 @@ interface Props {
   imageHeight?: number;
   imageType?: string;
   ogType?: "website" | "article";
+  articleHeadline?: string;
   articlePublishedTime?: Date | string;
   articleModifiedTime?: Date | string;
   articleTags?: string[];
@@ -22,12 +24,14 @@ const {
   imageHeight = 630,
   imageType = "image/png",
   ogType = "website",
+  articleHeadline,
   articlePublishedTime,
   articleModifiedTime,
   articleTags = [],
 } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const imageURL = new URL(image, Astro.site ?? Astro.url);
+const siteURL = Astro.site ?? new URL("/", Astro.url);
+const canonicalURL = new URL(Astro.url.pathname, siteURL);
+const imageURL = new URL(image, siteURL);
 
 function toMetaDateTime(value: Date | string | undefined) {
   if (!value) {
@@ -39,6 +43,22 @@ function toMetaDateTime(value: Date | string | undefined) {
 
 const publishedTime = toMetaDateTime(articlePublishedTime);
 const modifiedTime = toMetaDateTime(articleModifiedTime);
+const structuredData = buildPageStructuredData({
+  siteUrl: siteURL,
+  pageUrl: canonicalURL,
+  article:
+    ogType === "article" && articleHeadline && articlePublishedTime
+      ? {
+          headline: articleHeadline,
+          description,
+          datePublished: articlePublishedTime,
+          dateModified: articleModifiedTime,
+          image: imageURL,
+          tags: articleTags,
+        }
+      : undefined,
+});
+const serializedStructuredData = serializeJsonLd(structuredData);
 ---
 
 <ThemeInit />
@@ -79,6 +99,8 @@ const modifiedTime = toMetaDateTime(articleModifiedTime);
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={imageURL} />
+
+<script type="application/ld+json" set:html={serializedStructuredData} />
 
 <!-- Google Analytics -->
 {import.meta.env.PROD && (

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -100,7 +100,7 @@ const serializedStructuredData = serializeJsonLd(structuredData);
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={imageURL} />
 
-<script type="application/ld+json" set:html={serializedStructuredData} />
+<script type="application/ld+json" set:html={serializedStructuredData}></script>
 
 <!-- Google Analytics -->
 {import.meta.env.PROD && (

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -27,6 +27,12 @@ function readHtmlFiles(dir: string): string[] {
   });
 }
 
+function readStructuredData(html: string) {
+  const matches = [...html.matchAll(/<script type="application\/ld\+json">(.+?)<\/script>/gs)];
+
+  return matches.map((match) => JSON.parse(match[1]));
+}
+
 describe("BaseHead OGP meta tags", () => {
   beforeAll(() => {
     buildSite();
@@ -49,6 +55,36 @@ describe("BaseHead OGP meta tags", () => {
     expect(postHtml).not.toContain('<meta property="article:modified_time"');
   });
 
+  it("renders WebSite, Person, and BlogPosting JSON-LD on post pages", () => {
+    const postHtml = readHtmlFiles(join(distDir, "posts")).find(
+      (html) =>
+        html.includes("<title>Cookieとは - KJR020&#39;s Blog</title>") &&
+        html.includes('<meta property="article:tag" content="Cookie">'),
+    );
+
+    expect(postHtml).toBeDefined();
+
+    const structuredData = readStructuredData(postHtml ?? "");
+    const graph = structuredData[0]["@graph"];
+
+    expect(structuredData).toHaveLength(1);
+    expect(graph.map((entry: { "@type": string }) => entry["@type"])).toEqual([
+      "WebSite",
+      "Person",
+      "BlogPosting",
+    ]);
+    expect(graph[2]).toMatchObject({
+      "@type": "BlogPosting",
+      "@id": "https://kjr020.dev/posts/general/cookie%E3%81%A8%E3%81%AF/#blogposting",
+      headline: "Cookieとは",
+      description: "KJR020の技術ブログ",
+      datePublished: "2024-08-25T08:03:17.000Z",
+      dateModified: "2024-08-25T08:03:17.000Z",
+      author: { "@id": "https://kjr020.dev/#person" },
+      keywords: ["Cookie", "Web", "HTTP"],
+    });
+  });
+
   it("keeps website OGP type on non-post pages", () => {
     const indexHtml = readFileSync(join(distDir, "index.html"), "utf8");
 
@@ -65,6 +101,23 @@ describe("BaseHead OGP meta tags", () => {
     );
     expect(indexHtml).not.toContain('<meta property="article:published_time"');
     expect(indexHtml).not.toContain('<meta property="article:tag"');
+
+    const structuredData = readStructuredData(indexHtml);
+    const graph = structuredData[0]["@graph"];
+
+    expect(graph.map((entry: { "@type": string }) => entry["@type"])).toEqual([
+      "WebSite",
+      "Person",
+    ]);
+    expect(graph.some((entry: { "@type": string }) => entry["@type"] === "BlogPosting")).toBe(
+      false,
+    );
+  });
+
+  it("does not generate draft post pages", () => {
+    expect(existsSync(join(distDir, "posts", "graphql", "fetchpolicyについて", "index.html"))).toBe(
+      false,
+    );
   });
 
   it("ships the default OGP image at the recommended dimensions", async () => {

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -7,6 +7,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 const distDir = join(process.cwd(), "dist");
 const astroBin = join(process.cwd(), "node_modules", ".bin", "astro");
+const baseHeadPath = join(process.cwd(), "src", "layouts", "BaseHead.astro");
 
 function buildSite() {
   execFileSync(astroBin, ["build"], {
@@ -28,7 +29,11 @@ function readHtmlFiles(dir: string): string[] {
 }
 
 function readStructuredData(html: string) {
-  const matches = [...html.matchAll(/<script type="application\/ld\+json">(.+?)<\/script>/gs)];
+  const matches = [
+    ...html.matchAll(
+      /<script\b(?=[^>]*\btype\s*=\s*["']application\/ld\+json["'])[^>]*>([\s\S]*?)<\/script>/gi,
+    ),
+  ];
 
   return matches.map((match) => JSON.parse(match[1]));
 }
@@ -85,6 +90,24 @@ describe("BaseHead OGP meta tags", () => {
     });
   });
 
+  it("renders JSON-LD script with an explicit closing tag", () => {
+    const baseHeadSource = readFileSync(baseHeadPath, "utf8");
+
+    expect(baseHeadSource).toContain('<script type="application/ld+json"');
+    expect(baseHeadSource).not.toMatch(/<script[^>]*type="application\/ld\+json"[^>]*\/>/);
+    expect(baseHeadSource).toMatch(/<script[^>]*type="application\/ld\+json"[^>]*><\/script>/);
+  });
+
+  it("reads JSON-LD script even when script attributes change order or spacing", () => {
+    const [structuredData] = readStructuredData(
+      '<script data-kind="structured-data" type = \'application/ld+json\' nonce="abc">{"@context":"https://schema.org"}</script>',
+    );
+
+    expect(structuredData).toEqual({
+      "@context": "https://schema.org",
+    });
+  });
+
   it("keeps website OGP type on non-post pages", () => {
     const indexHtml = readFileSync(join(distDir, "index.html"), "utf8");
 
@@ -115,9 +138,13 @@ describe("BaseHead OGP meta tags", () => {
   });
 
   it("does not generate draft post pages", () => {
-    expect(existsSync(join(distDir, "posts", "graphql", "fetchpolicyについて", "index.html"))).toBe(
-      false,
-    );
+    const postHtmlFiles = readHtmlFiles(join(distDir, "posts"));
+
+    expect(
+      postHtmlFiles.some((html) =>
+        html.includes("<title>fetchPolicyについて - KJR020&#39;s Blog</title>"),
+      ),
+    ).toBe(false);
   });
 
   it("ships the default OGP image at the recommended dimensions", async () => {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ interface Props {
   image?: string;
   hideKuri?: boolean;
   ogType?: "website" | "article";
+  articleHeadline?: string;
   articlePublishedTime?: Date | string;
   articleModifiedTime?: Date | string;
   articleTags?: string[];
@@ -22,6 +23,7 @@ const {
   image,
   hideKuri = false,
   ogType,
+  articleHeadline,
   articlePublishedTime,
   articleModifiedTime,
   articleTags,
@@ -36,6 +38,7 @@ const {
       description={description}
       image={image}
       ogType={ogType}
+      articleHeadline={articleHeadline}
       articlePublishedTime={articlePublishedTime}
       articleModifiedTime={articleModifiedTime}
       articleTags={articleTags}

--- a/src/lib/structuredData.test.ts
+++ b/src/lib/structuredData.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { buildPageStructuredData, serializeJsonLd } from "./structuredData";
+
+describe("buildPageStructuredData", () => {
+  it("非記事ページでは WebSite と Person のみを生成する", () => {
+    const structuredData = buildPageStructuredData({
+      pageUrl: "https://kjr020.dev/",
+      siteUrl: "https://kjr020.dev",
+    });
+
+    expect(structuredData).toMatchObject({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://kjr020.dev/#website",
+          url: "https://kjr020.dev/",
+          name: "KJR020's Blog",
+          description: "KJR020の技術ブログ",
+          inLanguage: "ja",
+          publisher: { "@id": "https://kjr020.dev/#person" },
+        },
+        {
+          "@type": "Person",
+          "@id": "https://kjr020.dev/#person",
+          name: "KJR020",
+          url: "https://kjr020.dev/",
+          image: "https://kjr020.dev/images/kuri_photo.png",
+        },
+      ],
+    });
+    expect(structuredData["@graph"]).toHaveLength(2);
+    expect(structuredData["@graph"].some((entry) => entry["@type"] === "BlogPosting")).toBe(false);
+  });
+
+  it("記事ページでは BlogPosting を生成し、dateModified は公開日にフォールバックする", () => {
+    const structuredData = buildPageStructuredData({
+      pageUrl: "https://kjr020.dev/posts/astro/astro-pagefind-search/",
+      siteUrl: "https://kjr020.dev",
+      article: {
+        headline: "AstroにPagefind検索を追加した",
+        description: "Astro製ブログにPagefind検索を追加した記録です。",
+        datePublished: new Date("2026-01-20T09:30:00+09:00"),
+        tags: ["Astro", "Search", "Astro"],
+      },
+    });
+
+    expect(structuredData["@graph"]).toHaveLength(3);
+    expect(structuredData["@graph"][2]).toEqual({
+      "@type": "BlogPosting",
+      "@id": "https://kjr020.dev/posts/astro/astro-pagefind-search/#blogposting",
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": "https://kjr020.dev/posts/astro/astro-pagefind-search/",
+      },
+      headline: "AstroにPagefind検索を追加した",
+      description: "Astro製ブログにPagefind検索を追加した記録です。",
+      image: "https://kjr020.dev/og-image.png",
+      datePublished: "2026-01-20T00:30:00.000Z",
+      dateModified: "2026-01-20T00:30:00.000Z",
+      author: { "@id": "https://kjr020.dev/#person" },
+      publisher: { "@id": "https://kjr020.dev/#person" },
+      keywords: ["Astro", "Search"],
+      inLanguage: "ja",
+      isPartOf: { "@id": "https://kjr020.dev/#website" },
+    });
+  });
+});
+
+describe("serializeJsonLd", () => {
+  it("undefined を除外し、script 終了タグとして解釈されないようにエスケープする", () => {
+    const serialized = serializeJsonLd({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "</script><script>alert('xss')</script>",
+      description: undefined,
+      author: {
+        "@type": "Person",
+        name: "KJR020",
+        image: undefined,
+      },
+    });
+
+    expect(serialized).not.toContain("undefined");
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).not.toContain("<script>");
+    expect(serialized).toContain("\\u003C/script\\u003E");
+    expect(JSON.parse(serialized)).toEqual({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "</script><script>alert('xss')</script>",
+      author: {
+        "@type": "Person",
+        name: "KJR020",
+      },
+    });
+  });
+});

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -1,0 +1,136 @@
+type JsonLdValue = JsonLdPrimitive | JsonLdObject | JsonLdValue[];
+type JsonLdPrimitive = string | number | boolean | null;
+type JsonLdObject = { [key: string]: JsonLdValue | undefined };
+
+interface ArticleStructuredDataInput {
+  headline: string;
+  description?: string;
+  datePublished: Date | string;
+  dateModified?: Date | string;
+  image?: string | URL;
+  tags?: string[];
+}
+
+interface PageStructuredDataInput {
+  pageUrl: string | URL;
+  siteUrl: string | URL;
+  siteName?: string;
+  siteDescription?: string;
+  authorName?: string;
+  authorImage?: string | URL;
+  article?: ArticleStructuredDataInput;
+}
+
+export interface PageStructuredData {
+  "@context": "https://schema.org";
+  "@graph": JsonLdObject[];
+}
+
+const DEFAULT_SITE_NAME = "KJR020's Blog";
+const DEFAULT_SITE_DESCRIPTION = "KJR020の技術ブログ";
+const DEFAULT_AUTHOR_NAME = "KJR020";
+const DEFAULT_AUTHOR_IMAGE = "/images/kuri_photo.png";
+const DEFAULT_ARTICLE_IMAGE = "/og-image.png";
+const LANGUAGE = "ja";
+
+function toAbsoluteUrl(value: string | URL, baseUrl: string | URL) {
+  return new URL(value, baseUrl).toString();
+}
+
+function toIsoDateTime(value: Date | string) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function unique(values: string[] = []) {
+  return [...new Set(values)];
+}
+
+function removeUndefined(value: JsonLdValue | undefined): JsonLdValue | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => removeUndefined(item))
+      .filter((item): item is JsonLdValue => item !== undefined);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([key, item]) => [key, removeUndefined(item)] as const)
+        .filter(([, item]) => item !== undefined),
+    );
+  }
+
+  return value;
+}
+
+export function buildPageStructuredData({
+  pageUrl,
+  siteUrl,
+  siteName = DEFAULT_SITE_NAME,
+  siteDescription = DEFAULT_SITE_DESCRIPTION,
+  authorName = DEFAULT_AUTHOR_NAME,
+  authorImage = DEFAULT_AUTHOR_IMAGE,
+  article,
+}: PageStructuredDataInput): PageStructuredData {
+  const normalizedSiteUrl = toAbsoluteUrl(siteUrl, siteUrl);
+  const normalizedPageUrl = toAbsoluteUrl(pageUrl, normalizedSiteUrl);
+  const websiteId = toAbsoluteUrl("#website", normalizedSiteUrl);
+  const personId = toAbsoluteUrl("#person", normalizedSiteUrl);
+  const graph: JsonLdObject[] = [
+    {
+      "@type": "WebSite",
+      "@id": websiteId,
+      url: normalizedSiteUrl,
+      name: siteName,
+      description: siteDescription,
+      inLanguage: LANGUAGE,
+      publisher: { "@id": personId },
+    },
+    {
+      "@type": "Person",
+      "@id": personId,
+      name: authorName,
+      url: normalizedSiteUrl,
+      image: toAbsoluteUrl(authorImage, normalizedSiteUrl),
+    },
+  ];
+
+  if (article) {
+    graph.push({
+      "@type": "BlogPosting",
+      "@id": toAbsoluteUrl("#blogposting", normalizedPageUrl),
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": normalizedPageUrl,
+      },
+      headline: article.headline,
+      description: article.description ?? siteDescription,
+      image: toAbsoluteUrl(article.image ?? DEFAULT_ARTICLE_IMAGE, normalizedPageUrl),
+      datePublished: toIsoDateTime(article.datePublished),
+      dateModified: toIsoDateTime(article.dateModified ?? article.datePublished),
+      author: { "@id": personId },
+      publisher: { "@id": personId },
+      keywords: unique(article.tags),
+      inLanguage: LANGUAGE,
+      isPartOf: { "@id": websiteId },
+    });
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": graph,
+  };
+}
+
+export function serializeJsonLd(value: JsonLdValue) {
+  return JSON.stringify(removeUndefined(value))
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -7,7 +7,7 @@ import { TableOfContents } from "@/components/toc";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
+  const posts = await getCollection("posts", ({ data }) => !data.draft);
   return posts.map((post) => ({
     params: { slug: post.id },
     props: { post },
@@ -37,6 +37,7 @@ const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID;
   title={`${post.data.title} - KJR020's Blog`}
   description={post.data.description}
   ogType="article"
+  articleHeadline={post.data.title}
   articlePublishedTime={post.data.date}
   articleTags={post.data.tags}
 >


### PR DESCRIPTION
## Why

この PR は、検索エンジンが `kjr020.dev` のサイト情報・著者情報・公開記事の内容を機械可読に理解できるようにするためのものです。

現状は schema.org の JSON-LD がなく、Google などのクローラーに対して「これはブログ記事で、誰が書き、いつ公開され、どんなタグを持つのか」を明示できていません。WebSite / Person / BlogPosting を出すことで、リッチリザルト表示や検索結果での理解改善につながる土台を作ります。

## Scope

#48 の Phase 1 だけを対象にしています。

- WebSite: サイト全体の基本情報
- Person: 著者情報
- BlogPosting: 公開記事ページの headline / datePublished / dateModified / author / description / tags

BreadcrumbList とパンくず UI は #48 の Phase 2 として follow-up です。そのためこの PR は `Closes #48` ではなく `Refs #48` にしています。

## Changes

- `BaseHead` から全ページに WebSite / Person の JSON-LD を出力
- 公開記事ページだけ BlogPosting JSON-LD を追加
- JSON-LD 生成処理を `src/lib/structuredData.ts` に分離
- `undefined` を除外し、`</script>` を安全に扱うシリアライズを追加
- draft 記事を `getStaticPaths` から除外し、非公開記事ページに Article schema が出ないように変更
- JSON-LD 生成とビルド済み HTML 出力のテストを追加

Refs #48

## Validation

Codex 実行環境の pnpm registry が `npm.flatt.tech` で、lockfile は `registry.npmjs.org` の tarball を参照していたため、各コマンドは `--config.registry=https://registry.npmjs.org/` を付けて実行しました。

- `pnpm --config.registry=https://registry.npmjs.org/ lint`
- `pnpm --config.registry=https://registry.npmjs.org/ test:run`
- `pnpm --config.registry=https://registry.npmjs.org/ build`
- `pnpm --config.registry=https://registry.npmjs.org/ typecheck`