### PR TITLE
[codex] 脚注スタイルをブログデザインに合わせる

### DIFF
--- a/e2e/footnote.spec.ts
+++ b/e2e/footnote.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "playwright/test";
+
+test.describe("記事脚注スタイル", () => {
+  test("GFM脚注が記事デザインに馴染むスタイルで表示される", async ({ page }) => {
+    await page.goto("/posts/llm/harness-engineering/");
+
+    const footnotes = page.locator(".prose [data-footnotes]");
+    await expect(footnotes).toBeVisible();
+
+    const label = footnotes.locator("#footnote-label");
+    await expect(label).toHaveText("脚注");
+    await expect(label).toBeVisible();
+
+    const labelStyles = await label.evaluate((element) => {
+      const styles = getComputedStyle(element);
+
+      return {
+        display: styles.display,
+        position: styles.position,
+      };
+    });
+    expect(labelStyles.display).toBe("flex");
+    expect(labelStyles.position).not.toBe("absolute");
+
+    const sectionStyles = await footnotes.evaluate((element) => {
+      const styles = getComputedStyle(element);
+
+      return {
+        borderTopStyle: styles.borderTopStyle,
+        borderTopWidth: styles.borderTopWidth,
+      };
+    });
+    expect(sectionStyles.borderTopStyle).toBe("solid");
+    expect(Number.parseFloat(sectionStyles.borderTopWidth)).toBeGreaterThan(0);
+
+    const reference = page.locator(".prose [data-footnote-ref]").first();
+    await expect(reference).toBeVisible();
+
+    const referenceStyles = await reference.evaluate((element) => {
+      const styles = getComputedStyle(element);
+
+      return {
+        backgroundColor: styles.backgroundColor,
+        borderRadius: styles.borderRadius,
+        display: styles.display,
+        textDecorationLine: styles.textDecorationLine,
+      };
+    });
+    expect(referenceStyles.display).toBe("inline-flex");
+    expect(referenceStyles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(Number.parseFloat(referenceStyles.borderRadius)).toBeGreaterThan(0);
+    expect(referenceStyles.textDecorationLine).toBe("none");
+
+    const backReference = footnotes.locator("[data-footnote-backref]").first();
+    await expect(backReference).toBeVisible();
+
+    const backReferenceStyles = await backReference.evaluate((element) => {
+      const styles = getComputedStyle(element);
+
+      return {
+        borderTopStyle: styles.borderTopStyle,
+        display: styles.display,
+      };
+    });
+    expect(backReferenceStyles.display).toBe("inline-flex");
+    expect(backReferenceStyles.borderTopStyle).toBe("solid");
+  });
+});

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -263,6 +263,134 @@ const giscusCategoryId = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID;
     color: var(--link-hover);
   }
 
+  /* GFM脚注 */
+  .prose [data-footnotes] {
+    margin-top: 2.618rem; /* φ² */
+    padding-top: 1.618rem; /* φ */
+    border-top: 1px solid var(--border);
+    color: var(--muted-foreground);
+    font-size: var(--font-size-small);
+  }
+
+  .prose [data-footnotes] > h2 {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0 0 1rem;
+    padding: 0;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    white-space: normal;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 0;
+    color: var(--foreground);
+    font-size: var(--font-size-title3);
+    line-height: var(--lh-tight);
+    font-weight: 600;
+    letter-spacing: 0;
+  }
+
+  .prose [data-footnotes] > h2::before {
+    content: "※";
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.618rem; /* φ */
+    height: 1.618rem; /* φ */
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--link) 12%, transparent);
+    color: var(--link);
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+
+  .prose [data-footnotes] ol {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 1.618rem; /* φ */
+  }
+
+  .prose [data-footnotes] li {
+    margin-top: 0.618rem; /* 1/φ */
+    margin-bottom: 0.618rem; /* 1/φ */
+    padding-left: 0.382rem; /* φ⁻² */
+  }
+
+  .prose [data-footnotes] li::marker {
+    color: var(--muted-foreground);
+    font-weight: 600;
+  }
+
+  .prose [data-footnotes] p {
+    margin-top: 0;
+    margin-bottom: 0;
+    line-height: var(--lh-body);
+  }
+
+  .prose [data-footnote-ref] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.382rem; /* φ⁻² */
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--link) 12%, transparent);
+    color: var(--link);
+    font-size: 0.75em;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+  }
+
+  .prose [data-footnote-ref]:hover {
+    background-color: color-mix(in srgb, var(--link-hover) 18%, transparent);
+    color: var(--link-hover);
+  }
+
+  .prose [data-footnote-backref] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    height: 1.5rem;
+    margin-left: 0.236rem; /* φ⁻³ */
+    padding: 0 0.382rem; /* φ⁻² */
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background-color: var(--background);
+    color: var(--muted-foreground);
+    font-size: 0;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+    vertical-align: middle;
+  }
+
+  .prose [data-footnote-backref]::before {
+    content: "↩︎";
+    font-size: 0.75rem;
+  }
+
+  .prose [data-footnote-backref] sup {
+    margin-left: 0.05rem;
+    font-size: 0.65rem;
+  }
+
+  .prose [data-footnote-backref]:hover {
+    background-color: var(--muted);
+    color: var(--foreground);
+  }
+
+  .prose [data-footnote-ref]:focus-visible,
+  .prose [data-footnote-backref]:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+
   /* コードブロックのコピーボタン */
   .code-block-wrapper {
     position: relative;


### PR DESCRIPTION
## 概要

Closes #34

GFM脚注の見た目を、記事本文のproseスタイルに馴染むよう調整しました。

## 変更内容

- 本文中の脚注参照を下線リンクではなく小さなバッジ表示に変更
- 脚注セクションに区切り線、表示ラベル、脚注アイコン、読みやすいリスト余白を追加
- 戻りリンクを丸いテキストアイコンとして表示し、環境依存の絵文字風表示を避けるよう調整
- Harness Engineering 記事の脚注スタイルを確認する Playwright E2E を追加

## 検証

- `pnpm lint && pnpm test:run && pnpm build`
- `pnpm exec playwright test e2e/footnote.spec.ts`（chromium / Mobile Chrome）
- `/posts/llm/harness-engineering/` の脚注セクションを light / dark でスクリーンショット確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added styled footnotes in article pages, improving the appearance of footnote labels, references, and back-links.
  * Added end-to-end coverage to verify footnotes display correctly and keep their expected layout and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->