### PR TITLE
[codex] RSS フィードを実装する

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://kjr020.dev/",
   "dependencies": {
     "@astrojs/react": "^4.4.2",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.6.1",
     "@beoe/rehype-mermaid": "^0.4.2",
     "@giscus/react": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.4.2
         version: 4.4.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(yaml@2.8.2)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@astrojs/sitemap':
         specifier: ^3.6.1
         version: 3.6.1
@@ -159,6 +162,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==, tarball: https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz}
 
   '@astrojs/sitemap@3.6.1':
     resolution: {integrity: sha512-+o+TbxXqQJAOd+HxCjz/5RdAMrRFGjeuO+U6zddUuTO59WqMqXnsc8uveRiEr2Ff+3McZiEne7iG4J5cnuI6kA==}
@@ -1127,6 +1133,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==, tarball: https://npm.flatt.tech/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
 
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==, tarball: https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz}
+
   '@node-rs/xxhash-android-arm-eabi@1.7.6':
     resolution: {integrity: sha512-ptmfpFZ8SgTef58Us+0HsZ9BKhyX/gZYbhLkuzPt7qUoMqMSJK85NC7LEgzDgjUiG+S5GahEEQ9/tfh9BVvKhw==, tarball: https://npm.flatt.tech/@node-rs/xxhash-android-arm-eabi/-/xxhash-android-arm-eabi-1.7.6.tgz}
     engines: {node: '>= 12'}
@@ -1954,6 +1963,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==, tarball: https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -2511,6 +2523,13 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==, tarball: https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==, tarball: https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2691,6 +2710,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==, tarball: https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -3186,6 +3208,10 @@ packages:
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
+  path-expression-matcher@1.6.1:
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==, tarball: https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz}
+    engines: {node: '>=14.0.0'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==, tarball: https://npm.flatt.tech/path-to-regexp/-/path-to-regexp-6.3.0.tgz}
 
@@ -3452,6 +3478,9 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==, tarball: https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz}
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
@@ -3919,6 +3948,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==, tarball: https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -3968,6 +4001,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==, tarball: https://registry.npmjs.org/zod/-/zod-4.4.3.tgz}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4057,6 +4093,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.9.3
+      piccolore: 0.1.3
+      zod: 4.4.3
 
   '@astrojs/sitemap@3.6.1':
     dependencies:
@@ -4744,6 +4786,8 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nodable/entities@2.2.0': {}
 
   '@node-rs/xxhash-android-arm-eabi@1.7.6':
     optional: true
@@ -5476,6 +5520,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  anynum@1.0.1: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -6207,6 +6253,20 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.6.1
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.1
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -6444,6 +6504,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-unsafe@1.0.1: {}
 
   is-wsl@3.1.0:
     dependencies:
@@ -7129,6 +7191,8 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
+  path-expression-matcher@1.6.1: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -7493,6 +7557,10 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   stylis@4.3.6: {}
 
   supports-color@10.2.2: {}
@@ -7851,6 +7919,8 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml-naming@0.1.0: {}
+
   xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
@@ -7893,5 +7963,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,7 @@ packages:
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
   '@astrojs/rss@4.0.18':
-    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==, tarball: https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz}
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==, tarball: https://npm.flatt.tech/@astrojs/rss/-/rss-4.0.18.tgz}
 
   '@astrojs/sitemap@3.6.1':
     resolution: {integrity: sha512-+o+TbxXqQJAOd+HxCjz/5RdAMrRFGjeuO+U6zddUuTO59WqMqXnsc8uveRiEr2Ff+3McZiEne7iG4J5cnuI6kA==}
@@ -1134,7 +1134,7 @@ packages:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==, tarball: https://npm.flatt.tech/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
 
   '@nodable/entities@2.2.0':
-    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==, tarball: https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz}
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==, tarball: https://npm.flatt.tech/@nodable/entities/-/entities-2.2.0.tgz}
 
   '@node-rs/xxhash-android-arm-eabi@1.7.6':
     resolution: {integrity: sha512-ptmfpFZ8SgTef58Us+0HsZ9BKhyX/gZYbhLkuzPt7qUoMqMSJK85NC7LEgzDgjUiG+S5GahEEQ9/tfh9BVvKhw==, tarball: https://npm.flatt.tech/@node-rs/xxhash-android-arm-eabi/-/xxhash-android-arm-eabi-1.7.6.tgz}
@@ -1964,7 +1964,7 @@ packages:
     engines: {node: '>= 8'}
 
   anynum@1.0.1:
-    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==, tarball: https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz}
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==, tarball: https://npm.flatt.tech/anynum/-/anynum-1.0.1.tgz}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2524,10 +2524,10 @@ packages:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-xml-builder@1.2.0:
-    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==, tarball: https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz}
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==, tarball: https://npm.flatt.tech/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz}
 
   fast-xml-parser@5.9.3:
-    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==, tarball: https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz}
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==, tarball: https://npm.flatt.tech/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz}
     hasBin: true
 
   fdir@6.5.0:
@@ -2712,7 +2712,7 @@ packages:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-unsafe@1.0.1:
-    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==, tarball: https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz}
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==, tarball: https://npm.flatt.tech/is-unsafe/-/is-unsafe-1.0.1.tgz}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -3209,7 +3209,7 @@ packages:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-expression-matcher@1.6.1:
-    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==, tarball: https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz}
+    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==, tarball: https://npm.flatt.tech/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz}
     engines: {node: '>=14.0.0'}
 
   path-to-regexp@6.3.0:
@@ -3480,7 +3480,7 @@ packages:
     engines: {node: '>=8'}
 
   strnum@2.4.1:
-    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==, tarball: https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz}
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==, tarball: https://npm.flatt.tech/strnum/-/strnum-2.4.1.tgz}
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
@@ -3949,7 +3949,7 @@ packages:
     engines: {node: '>=18'}
 
   xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==, tarball: https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz}
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==, tarball: https://npm.flatt.tech/xml-naming/-/xml-naming-0.1.0.tgz}
     engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
@@ -4003,7 +4003,7 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==, tarball: https://registry.npmjs.org/zod/-/zod-4.4.3.tgz}
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==, tarball: https://npm.flatt.tech/zod/-/zod-4.4.3.tgz}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,11 +1,13 @@
 ---
+import { Rss } from "lucide-react";
+
 const currentYear = new Date().getFullYear();
 
 const socialLinks = [
   {
     href: "/rss.xml",
     label: "RSS",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>`,
+    icon: "rss",
   },
   {
     href: "https://github.com/KJR020",
@@ -38,7 +40,11 @@ const socialLinks = [
             class="text-muted-foreground transition-colors hover:text-foreground"
             aria-label={link.label}
           >
-            <Fragment set:html={link.icon} />
+            {link.icon === "rss" ? (
+              <Rss size={19} strokeWidth={2.25} aria-hidden="true" />
+            ) : (
+              <Fragment set:html={link.icon} />
+            )}
           </a>
         ))}
       </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,13 +3,20 @@ const currentYear = new Date().getFullYear();
 
 const socialLinks = [
   {
+    href: "/rss.xml",
+    label: "RSS",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>`,
+  },
+  {
     href: "https://github.com/KJR020",
     label: "GitHub",
+    external: true,
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`,
   },
   {
     href: "https://x.com/kjr020",
     label: "X",
+    external: true,
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>`,
   },
 ];
@@ -26,8 +33,8 @@ const socialLinks = [
         {socialLinks.map((link) => (
           <a
             href={link.href}
-            target="_blank"
-            rel="noopener noreferrer"
+            target={link.external ? "_blank" : undefined}
+            rel={link.external ? "noopener noreferrer" : undefined}
             class="text-muted-foreground transition-colors hover:text-foreground"
             aria-label={link.label}
           >

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -59,6 +59,7 @@ const structuredData = buildPageStructuredData({
       : undefined,
 });
 const serializedStructuredData = serializeJsonLd(structuredData);
+const rssFeedURL = new URL("/rss.xml", siteURL);
 ---
 
 <ThemeInit />
@@ -67,6 +68,12 @@ const serializedStructuredData = serializeJsonLd(structuredData);
 <link rel="icon" type="image/png" href="/images/kuri_photo.png" />
 <link rel="apple-touch-icon" href="/images/kuri_photo.png" />
 <link rel="canonical" href={canonicalURL} />
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="KJR020 Blog RSS Feed"
+  href={rssFeedURL}
+/>
 
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -39,8 +39,13 @@ function readStructuredData(html: string) {
 }
 
 describe("BaseHead OGP meta tags", () => {
+  let rssXml = "";
+
   beforeAll(() => {
     buildSite();
+
+    const rssPath = join(distDir, "rss.xml");
+    rssXml = existsSync(rssPath) ? readFileSync(rssPath, "utf8") : "";
   }, 60_000);
 
   it("renders article OGP meta tags on post pages", () => {
@@ -110,6 +115,11 @@ describe("BaseHead OGP meta tags", () => {
 
   it("keeps website OGP type on non-post pages", () => {
     const indexHtml = readFileSync(join(distDir, "index.html"), "utf8");
+    const indexDoc = new DOMParser().parseFromString(indexHtml, "text/html");
+    const rssHeadLink = indexDoc.querySelector(
+      'link[rel="alternate"][type="application/rss+xml"]',
+    );
+    const rssFooterLink = indexDoc.querySelector('a[aria-label="RSS"]');
 
     expect(indexHtml).toContain('<meta property="og:type" content="website">');
     expect(indexHtml).toContain('<meta property="og:locale" content="ja_JP">');
@@ -122,6 +132,9 @@ describe("BaseHead OGP meta tags", () => {
     expect(indexHtml).toContain(
       '<meta name="twitter:image" content="https://kjr020.dev/og-image.png">',
     );
+    expect(rssHeadLink?.getAttribute("title")).toBe("KJR020 Blog RSS Feed");
+    expect(rssHeadLink?.getAttribute("href")).toBe("https://kjr020.dev/rss.xml");
+    expect(rssFooterLink?.getAttribute("href")).toBe("/rss.xml");
     expect(indexHtml).not.toContain('<meta property="article:published_time"');
     expect(indexHtml).not.toContain('<meta property="article:tag"');
 
@@ -157,5 +170,39 @@ describe("BaseHead OGP meta tags", () => {
     expect(metadata.format).toBe("png");
     expect(metadata.width).toBe(1200);
     expect(metadata.height).toBe(630);
+  });
+
+  it("generates an RSS feed for subscribers", () => {
+    const rssDoc = new DOMParser().parseFromString(rssXml, "application/xml");
+
+    expect(rssXml).toContain("<rss");
+    expect(rssXml).toContain("<channel>");
+    expect(rssDoc.querySelector("channel > title")?.textContent).toBe("KJR020's Blog");
+    expect(rssDoc.querySelector("channel > link")?.textContent).toBe("https://kjr020.dev/");
+  });
+
+  it("includes public posts and excludes draft posts from the RSS feed", () => {
+    const rssDoc = new DOMParser().parseFromString(rssXml, "application/xml");
+    const itemTitles = Array.from(rssDoc.querySelectorAll("item > title")).map((title) =>
+      title.textContent?.trim(),
+    );
+
+    expect(itemTitles).toContain(
+      "OpenAIが実践するAgent-First時代の開発アプローチ — Harness Engineering",
+    );
+    expect(itemTitles).toContain("Cookieとは");
+    expect(itemTitles).not.toContain("Python標準ライブラリgraphlibでDAG並列実行エンジンを作った");
+    expect(itemTitles).not.toContain("FetchPolicyについて");
+  });
+
+  it("orders RSS feed items by publish date descending", () => {
+    const rssDoc = new DOMParser().parseFromString(rssXml, "application/xml");
+    const pubDates = Array.from(rssDoc.querySelectorAll("item > pubDate")).map((pubDate) =>
+      Date.parse(pubDate.textContent ?? ""),
+    );
+
+    expect(pubDates.length).toBeGreaterThan(1);
+    expect(pubDates.every(Number.isFinite)).toBe(true);
+    expect(pubDates).toEqual([...pubDates].sort((a, b) => b - a));
   });
 });

--- a/src/layouts/BaseHead.ogp.test.ts
+++ b/src/layouts/BaseHead.ogp.test.ts
@@ -116,9 +116,7 @@ describe("BaseHead OGP meta tags", () => {
   it("keeps website OGP type on non-post pages", () => {
     const indexHtml = readFileSync(join(distDir, "index.html"), "utf8");
     const indexDoc = new DOMParser().parseFromString(indexHtml, "text/html");
-    const rssHeadLink = indexDoc.querySelector(
-      'link[rel="alternate"][type="application/rss+xml"]',
-    );
+    const rssHeadLink = indexDoc.querySelector('link[rel="alternate"][type="application/rss+xml"]');
     const rssFooterLink = indexDoc.querySelector('a[aria-label="RSS"]');
 
     expect(indexHtml).toContain('<meta property="og:type" content="website">');
@@ -178,7 +176,7 @@ describe("BaseHead OGP meta tags", () => {
     expect(rssXml).toContain("<rss");
     expect(rssXml).toContain("<channel>");
     expect(rssDoc.querySelector("channel > title")?.textContent).toBe("KJR020's Blog");
-    expect(rssDoc.querySelector("channel > link")?.textContent).toBe("https://kjr020.dev/");
+    expect(rssDoc.querySelector("channel > link")?.textContent).toBe("https://kjr020.dev");
   });
 
   it("includes public posts and excludes draft posts from the RSS feed", () => {
@@ -204,5 +202,16 @@ describe("BaseHead OGP meta tags", () => {
     expect(pubDates.length).toBeGreaterThan(1);
     expect(pubDates.every(Number.isFinite)).toBe(true);
     expect(pubDates).toEqual([...pubDates].sort((a, b) => b - a));
+  });
+
+  it("uses canonical post links without trailing slashes in RSS items", () => {
+    const rssDoc = new DOMParser().parseFromString(rssXml, "application/xml");
+    const itemLinks = Array.from(rssDoc.querySelectorAll("item > link")).map((link) =>
+      link.textContent?.trim(),
+    );
+
+    expect(itemLinks.length).toBeGreaterThan(1);
+    expect(itemLinks.every((link) => link?.startsWith("https://kjr020.dev/posts/"))).toBe(true);
+    expect(itemLinks.every((link) => !link?.endsWith("/"))).toBe(true);
   });
 });

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,24 @@
+import { getCollection } from "astro:content";
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection("posts", ({ data }) => !data.draft);
+  const sortedPosts = posts.sort(
+    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+  );
+
+  return rss({
+    title: "KJR020's Blog",
+    description: "KJR020の技術ブログ",
+    site: context.site?.toString() ?? "https://kjr020.dev",
+    items: sortedPosts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      link: `/posts/${post.id}`,
+      categories: post.data.tags,
+    })),
+    customData: "<language>ja-jp</language>",
+  });
+}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -12,6 +12,7 @@ export async function GET(context: APIContext) {
     title: "KJR020's Blog",
     description: "KJR020の技術ブログ",
     site: context.site?.toString() ?? "https://kjr020.dev",
+    trailingSlash: false,
     items: sortedPosts.map((post) => ({
       title: post.data.title,
       description: post.data.description,


### PR DESCRIPTION
## 概要

- `@astrojs/rss` を追加し、`/rss.xml` を生成するエンドポイントを実装
- content collection の `draft` フラグを見て draft 記事を RSS から除外し、公開日降順で配信
- `<link rel="alternate" type="application/rss+xml">` と footer の RSS 導線を追加
- RSS の生成、公開記事の含有、draft 除外、日付降順をテストで確認

## 検証

- `pnpm lint && pnpm test:run && pnpm build`

Closes #50